### PR TITLE
Update for rust 1.41 (mem::replace -> mem::take))

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-quinn = "0.5.2"
+quinn = "^0.5.2"
 futures = "*"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
 unwrap = "~1.2.1"
@@ -25,8 +25,8 @@ rcgen = "~0.7.0"
 rustls = "~0.16.0"
 log = "~0.4.6"
 base64 = "~0.10.1"
-err-derive = "0.2.2"
-derive_more = "0.99.2"
+err-derive = "^0.2.2"
+derive_more = "^0.99.2"
 
 [dev-dependencies]
 clap = "~2.32.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-quinn = "^0.5.2"
+quinn = "^0.5.3"
 futures = "*"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
 unwrap = "~1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-quinn = "~0.5.2"
+quinn = "0.5.2"
 futures = "*"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
 unwrap = "~1.2.1"
@@ -21,11 +21,12 @@ crossbeam-channel = "~0.3.8"
 serde = { version = "~1.0.91", features = ["derive"] }
 serde_json = "~1.0.39"
 structopt = "~0.2.15"
-quick-error = "~1.2.2"
 rcgen = "~0.7.0"
 rustls = "~0.16.0"
 log = "~0.4.6"
 base64 = "~0.10.1"
+err-derive = "0.2.2"
+derive_more = "0.99.2"
 
 [dev-dependencies]
 clap = "~2.32.0"

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -343,7 +343,3 @@ impl From<SocketAddr> for NodeInfo {
         }
     }
 }
-
-/// `QuicP2p` error.
-#[derive(Debug)]
-pub struct Error;

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -29,6 +29,9 @@ use structopt::StructOpt;
 
 pub type Token = u64;
 
+#[derive(Debug)]
+pub struct QuicP2pError;
+
 /// Builder for `QuickP2p`.
 pub struct Builder {
     event_tx: Sender<Event>,
@@ -52,7 +55,7 @@ impl Builder {
     }
 
     /// Construct `QuicP2p` with supplied parameters earlier, ready to be used.
-    pub fn build(self) -> Result<QuicP2p, Error> {
+    pub fn build(self) -> Result<QuicP2p, QuicP2pError> {
         Ok(QuicP2p::new(
             self.event_tx,
             self.config.unwrap_or_else(Config::default),
@@ -98,12 +101,12 @@ impl QuicP2p {
     }
 
     /// Get our connection info to give to others for them to connect to us
-    pub fn our_connection_info(&mut self) -> Result<NodeInfo, Error> {
+    pub fn our_connection_info(&mut self) -> Result<NodeInfo, QuicP2pError> {
         self.inner.borrow().our_connection_info()
     }
 
     /// Retrieves current node bootstrap cache.
-    pub fn bootstrap_cache(&mut self) -> Result<Vec<NodeInfo>, Error> {
+    pub fn bootstrap_cache(&mut self) -> Result<Vec<NodeInfo>, QuicP2pError> {
         Ok(self.inner.borrow().bootstrap_cache())
     }
 
@@ -244,7 +247,7 @@ pub enum Event {
         /// Address of the peer we attempted connecting to.
         peer_addr: SocketAddr,
         /// Error explaining connection failure.
-        err: Error,
+        err: QuicP2pError,
     },
     /// Message sent by us but not delivered due to connection drop.
     UnsentUserMessage {

--- a/mock/src/node.rs
+++ b/mock/src/node.rs
@@ -8,7 +8,7 @@
 
 use super::{
     network::{Inner, Packet, NETWORK},
-    Config, Error, Event, NodeInfo, OurType, Peer,
+    Config, Event, NodeInfo, OurType, Peer, QuicP2pError,
 };
 use bytes::Bytes;
 use crossbeam_channel::Sender;
@@ -213,7 +213,7 @@ impl Node {
                 if self.peers.remove(&src).is_some() {
                     self.fire_event(Event::ConnectionFailure {
                         peer_addr: src,
-                        err: Error,
+                        err: QuicP2pError,
                     })
                 }
             }
@@ -222,9 +222,9 @@ impl Node {
         None
     }
 
-    pub fn our_connection_info(&self) -> Result<NodeInfo, Error> {
+    pub fn our_connection_info(&self) -> Result<NodeInfo, QuicP2pError> {
         match self.config.our_type {
-            OurType::Client => Err(Error),
+            OurType::Client => Err(QuicP2pError),
             OurType::Node => Ok(NodeInfo::from(self.addr)),
         }
     }

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -9,7 +9,7 @@
 
 use crate::dirs::Dirs;
 use crate::utils;
-use crate::{Error, NodeInfo, R};
+use crate::{NodeInfo, QuicP2pError, R};
 use log::info;
 use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
@@ -44,7 +44,7 @@ impl BootstrapCache {
         };
 
         let cache_path = user_override.map_or_else(
-            || Ok::<_, Error>(path(&utils::project_dir()?)),
+            || Ok::<_, QuicP2pError>(path(&utils::project_dir()?)),
             |d| Ok(path(d)),
         )?;
 
@@ -54,7 +54,7 @@ impl BootstrapCache {
             let cache_dir = cache_path
                 .parent()
                 .ok_or_else(|| io::ErrorKind::NotFound.into())
-                .map_err(Error::Io)?;
+                .map_err(QuicP2pError::Io)?;
             fs::create_dir_all(&cache_dir)?;
             Default::default()
         };

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -66,8 +66,10 @@ pub fn try_write_to_peer(peer: Peer, msg: WireMsg, token: Token) -> R<()> {
                 ..
             } => {
                 if *peer_cert_der != node_info.peer_cert_der {
-                    info!("TODO Certificate we have for the peer already doesn't match with the \
-                    one given - we should disconnect from such peers - something fishy going on.");
+                    info!(
+                        "TODO Certificate we have for the peer already doesn't match with the \
+                    one given - we should disconnect from such peers - something fishy going on."
+                    );
                 }
                 pending_sends.push((msg, token));
                 None
@@ -208,7 +210,7 @@ pub fn read_from_peer(
                     From::from(e)
                 }
                 Ok((_o_stream, _i_stream)) => {
-                    let e = QuicP2pError::BiDirectionalStreamAttempted{ peer_addr };
+                    let e = QuicP2pError::BiDirectionalStreamAttempted { peer_addr };
                     debug!(
                         "Error in Incoming-streams while reading from peer {}: {:?} - {}.",
                         peer_addr, e, e
@@ -261,9 +263,12 @@ pub fn handle_wire_msg(peer_addr: SocketAddr, wire_msg: WireMsg) {
                 let conn = match c.connections.get_mut(&peer_addr) {
                     Some(conn) => conn,
                     None => {
-                        trace!("Rxd wire-message from someone we don't know. Probably it was a \
+                        trace!(
+                            "Rxd wire-message from someone we don't know. Probably it was a \
                         pending stream when we dropped the peer connection. Ignoring this message \
-                        from peer: {}", peer_addr);
+                        from peer: {}",
+                            peer_addr
+                        );
                         return;
                     }
                 };
@@ -373,9 +378,11 @@ fn handle_rx_handshake(peer_addr: SocketAddr, handshake: Handshake) {
         let conn = match c.connections.get_mut(&peer_addr) {
             Some(conn) => conn,
             None => {
-                trace!("Rxd handshake from someone we don't know. Probably it was a pending \
+                trace!(
+                    "Rxd handshake from someone we don't know. Probably it was a pending \
                 stream when we dropped the peer connection. Ignoring this message from peer: {}",
-                peer_addr);
+                    peer_addr
+                );
                 return;
             }
         };
@@ -419,9 +426,11 @@ fn handle_rx_cert(peer_addr: SocketAddr, peer_cert_der: Vec<u8>) {
         let conn = match c.connections.get_mut(&peer_addr) {
             Some(conn) => conn,
             None => {
-                trace!("Rxd certificate from someone we don't know. Probably it was a pending \
+                trace!(
+                    "Rxd certificate from someone we don't know. Probably it was a pending \
                 stream when we dropped the peer connection. Ignoring this message from peer: {}",
-                peer_addr);
+                    peer_addr
+                );
                 return false;
             }
         };
@@ -442,9 +451,11 @@ fn handle_rx_cert(peer_addr: SocketAddr, peer_cert_der: Vec<u8>) {
                 ref peer_cert_der, ..
             } => {
                 if *peer_cert_der != node_info.peer_cert_der {
-                    info!("TODO Certificate we have for the peer already doesn't match with \
+                    info!(
+                        "TODO Certificate we have for the peer already doesn't match with \
                         the one given - we should disconnect to such peers - something fishy going \
-                        on.");
+                        on."
+                    );
                 }
                 false
             }
@@ -527,7 +538,10 @@ mod tests {
         match rx0.recv() {
             Ok(Event::ConnectionFailure { peer_addr, err }) => {
                 assert_eq!(peer_addr, qp2p1_info.peer_addr);
-                assert_eq!(format!("{}", err), format!("{}" , QuicP2pError::ConnectionCancelled));
+                assert_eq!(
+                    format!("{}", err),
+                    format!("{}", QuicP2pError::ConnectionCancelled)
+                );
             }
             r => panic!("Unexpected result {:?}", r),
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -105,7 +105,7 @@ pub fn connect_to(
 
             Ok(())
         } else {
-            Err(QuicP2pError::DuplicateConnectionToPeer{ peer_addr })
+            Err(QuicP2pError::DuplicateConnectionToPeer { peer_addr })
         }
     });
 
@@ -156,10 +156,7 @@ fn handle_new_connection_res(
                 ref mut peer_cert_der,
                 ref mut pending_sends,
                 ..
-            } => (
-                mem::take(peer_cert_der),
-                mem::take(pending_sends),
-            ),
+            } => (mem::take(peer_cert_der), mem::take(pending_sends)),
             // TODO analyse if this is actually reachable in some wierd case where things were in
             // the event loop and resolving now etc
             x => unreachable!(
@@ -271,7 +268,7 @@ fn handle_connect_err(peer_addr: SocketAddr, e: &QuicP2pError) {
         peer_addr, e, e
     );
 
-    if let QuicP2pError::DuplicateConnectionToPeer{ .. } = e {
+    if let QuicP2pError::DuplicateConnectionToPeer { .. } = e {
         return;
     }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -87,8 +87,7 @@ pub fn connect_to(
 
             let connecting = c
                 .quic_ep()
-                .connect_with(peer_cfg, &peer_addr, "MaidSAFE.net")
-                .map_err(QuicP2pError::from)?;
+                .connect_with(peer_cfg, &peer_addr, "MaidSAFE.net")?;
 
             let _ = tokio::spawn(async move {
                 select! {

--- a/src/connection/bootstrap_group.rs
+++ b/src/connection/bootstrap_group.rs
@@ -91,7 +91,7 @@ impl BootstrapGroupRef {
 
             // We use a `mem::replace` here because `self.group` can be mutably borrowed
             // twice during `BootstrapGroupRef::drop` (it's called when we remove a connection)
-            mem::replace(&mut group.terminators, Default::default())
+            mem::take(&mut group.terminators)
         };
 
         let _ = terminators.remove(&self.peer_addr);

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -13,7 +13,7 @@ pub use self::q_conn::QConn;
 pub use self::to_peer::ToPeer;
 
 use crate::context::ctx_mut;
-use crate::error::Error;
+use crate::error::QuicP2pError;
 use crate::event::Event;
 use crossbeam_channel as mpmc;
 use futures::future::FutureExt;
@@ -80,7 +80,7 @@ impl Drop for Connection {
             // that point there might be no one listening so sender will error out
             let _ = self.event_tx.send(Event::ConnectionFailure {
                 peer_addr: self.peer_addr,
-                err: Error::ConnectionCancelled,
+                err: QuicP2pError::ConnectionCancelled,
             });
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ pub enum QuicP2pError {
     ConnectionCancelled,
     #[error(display = "Channel receive error ")]
     ChannelRecv(#[source] mpsc::RecvError),
+    #[error(display = "Could not add certificate to PKI")]
+    WebPki,
     #[error(display = "Invalid wire message.")]
     InvalidWireMsgFlag,
     #[error(display = "Stream write error ")]
@@ -57,5 +59,5 @@ pub enum QuicP2pError {
     #[error(display = "Read to end error ")]
     ReadToEndError(#[source] quinn::ReadToEndError),
     #[error(display = "Could not add certificate ")]
-    AddCertificateError,
+    AddCertificateError(#[source] quinn::ParseError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,115 +7,55 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use quick_error::quick_error;
+use err_derive::Error;
+
 use std::io;
 use std::net::SocketAddr;
 use std::sync::mpsc;
 
-quick_error! {
-    #[derive(Debug)]
-     /// Error types encountered during the operation of this library.
-     pub enum Error {
-         /// Error type associated with I/O operations.
-         Io(e: io::Error) {
-             display("IO Error: {}", e)
-             from()
-         }
-         /// Errors encountered while reading from a QUIC stream.
-         Read(e: quinn::ReadError) {
-             display("Read Error: {}", e)
-             from()
-         }
-         /// Error returned when a Bi-directional stream is attempted by a peer.
-         BiDirectionalStreamAttempted(peer_addr: SocketAddr) {
-             display("Bi-directional stream attempted by peer {}", peer_addr)
-         }
-         /// Errors encountered while creating a new connection.
-         Connect(e: quinn::ConnectError) {
-             display("Connection Error: {}", e)
-             from()
-         }
-         /// Errors explaining why an established connection might be lost.
-         Connection(e: quinn::ConnectionError) {
-             display("Connection Error: {}", e)
-             from()
-         }
-         /// Error while creating a quinn endpoint
-         Endpoint(e: quinn::EndpointError) {
-             display("Endpoint error: {}", e)
-             from()
-         }
-         /// Error encountered while parsing a certificate or key.
-         CertificateParseError(e: String) {
-             display("Certificate Parse Error: {}", e)
-             from()
-         }
-         /// Error returned when a duplicate connection to a peer is attempted.
-         DuplicateConnectionToPeer(peer_addr: SocketAddr) {
-             display("Duplicate connection attempted to peer {}", peer_addr)
-         }
-         /// Error returned when an endpoint echo server is not found.
-         NoEndpointEchoServerFound {
-             display("There's no endpoint echo server to ask. Current network configuration")
-         }
-         /// Error returned when a receive operation on a channel fails.
-         OneShotRx(e: tokio::sync::oneshot::error::RecvError) {
-             display("Oneshot Receiver error: {}", e)
-             from()
-         }
-         /// Errors encountered while establishing TLS.
-         TLS(e: rustls::TLSError) {
-             display("TLE error: {}", e)
-             from()
-         }
-         /// Error produced when (de)serialisation is unsuccessful.
-         Bincode(e: bincode::Error) {
-             display("Bincode error: {}", e)
-             from()
-         }
-         /// Errors encountered while decoding Base64 values.
-         Base64(e: base64::DecodeError) {
-             display("Base64 decoding error: {}", e)
-             from()
-         }
-         /// Error produced when configuration is not understood.
-         Configuration(e: String) {
-             display("Configuration error: {}", e)
-         }
-         /// Forbidden operation attempted
-         OperationNotAllowed {
-             display("This operation is not allowed for us")
-         }
-         /// Connection Cancelled
-         ConnectionCancelled {
-             display("Connection was actively cancelled")
-             from()
-         }
-         /// Failed receiving from an `mpsc::channel`.
-         ChannelRecv(e: mpsc::RecvError) {
-             display("Channel receive error: {}", e)
-             cause(e)
-             from()
-         }
-         /// Could not deserialise a wire message.
-         InvalidWireMsgFlag {
-             display("Could not deserialise a wire message: unexpected message type flag")
-         }
-         /// Write error
-         WriteError(e: quinn::WriteError) {
-             display("Stream Write error: {}", e)
-             cause(e)
-             from()
-         }
-         /// Read to end error
-         ReadToEndError(e: quinn::ReadToEndError) {
-             display("Read to end error: {}", e)
-             cause(e)
-             from()
-         }
-         /// Add certificate error
-         AddCertificateError(e: String) {
-             display("Could not add certificate: {}", e)
-         }
-     }
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum QuicP2pError {
+    #[error(display = "I/O Error")]
+    Io(#[source] io::Error),
+    #[error(display = "quinn read")]
+    Read(#[source] quinn::ReadError),
+    #[error(display = "Bi-directional stream attempted by peer {}", peer_addr)]
+    BiDirectionalStreamAttempted { peer_addr: SocketAddr },
+    #[error(display = "Establishing connection")]
+    Connect(#[source] quinn::ConnectError),
+    #[error(display = "Connection lost")]
+    Connection(#[source] quinn::ConnectionError),
+    #[error(display = "Creating endpoint")]
+    Endpoint(#[source] quinn::EndpointError),
+    #[error(display = "Cannot parse certificate ")]
+    CertificateParseError,
+    #[error(display = "Already connected {}", peer_addr)]
+    DuplicateConnectionToPeer { peer_addr: SocketAddr },
+    #[error(display = "Could not find enpoint server")]
+    NoEndpointEchoServerFound,
+    #[error(display = "Oneshot receiver ")]
+    OneShotRx(#[source] tokio::sync::oneshot::error::RecvError),
+    #[error(display = "TLS Error ")]
+    TLS(#[source] rustls::TLSError),
+    #[error(display = "Bincode serialisation")]
+    Bincode(#[source] bincode::Error),
+    #[error(display = "Base64 decode ")]
+    Base64(#[source] base64::DecodeError),
+    #[error(display = "Configuration {}", e)]
+    Configuration { e: String },
+    #[error(display = "Operation not allowed")]
+    OperationNotAllowed,
+    #[error(display = "Connection cancelled")]
+    ConnectionCancelled,
+    #[error(display = "Channel receive error ")]
+    ChannelRecv(#[source] mpsc::RecvError),
+    #[error(display = "Invalid wire message.")]
+    InvalidWireMsgFlag,
+    #[error(display = "Stream write error ")]
+    WriteError(#[source] quinn::WriteError),
+    #[error(display = "Read to end error ")]
+    ReadToEndError(#[source] quinn::ReadToEndError),
+    #[error(display = "Could not add certificate ")]
+    AddCertificateError,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::QuicP2pError;
 use crate::{utils, NodeInfo, Peer};
 use std::fmt;
 use std::net::SocketAddr;
@@ -19,7 +19,7 @@ pub enum Event {
         /// Peer address.
         peer_addr: SocketAddr,
         /// Error explaining connection failure.
-        err: Error,
+        err: QuicP2pError,
     },
     /// The given message was successfully sent to this peer.
     SentUserMessage {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -12,8 +12,8 @@ use crate::connection::{BootstrapGroupRef, Connection, FromPeer, QConn, ToPeer};
 use crate::context::ctx_mut;
 use crate::event::Event;
 use crate::utils;
-use crate::Error;
 use crate::NodeInfo;
+use crate::QuicP2pError;
 use futures::future::{self, TryFutureExt};
 use futures::stream::StreamExt;
 use log::{debug, info};
@@ -110,7 +110,7 @@ fn handle_new_conn(
         }
         Action::HandleAlreadyBootstrapped => crate::utils::handle_communication_err(
             peer_addr,
-            &Error::ConnectionCancelled,
+            &QuicP2pError::ConnectionCancelled,
             "Connection already bootstrapped",
             None,
         ),

--- a/src/peer_config.rs
+++ b/src/peer_config.rs
@@ -26,11 +26,7 @@ pub const DEFAULT_IDLE_TIMEOUT_MSEC: u64 = 30_000; // 30secs
 pub const DEFAULT_KEEP_ALIVE_INTERVAL_MSEC: u32 = 10_000; // 10secs
 
 pub fn new_client_cfg(peer_cert_der: &[u8]) -> R<quinn::ClientConfig> {
-    // FIXME: Seems quinn have `ParseError` as a return type of a public interface but the type
-    // itself is private. Hence using this workaround to collect it via `format!`. Ideally should
-    // be just convertible inside quick_error as usual with other errors.
-    let peer_cert = quinn::Certificate::from_der(peer_cert_der)
-        .map_err(|_| QuicP2pError::CertificateParseError)?;
+    let peer_cert = quinn::Certificate::from_der(peer_cert_der)?;
 
     let mut peer_cfg_builder = {
         let mut client_cfg = quinn::ClientConfig::default();
@@ -40,7 +36,7 @@ pub fn new_client_cfg(peer_cert_der: &[u8]) -> R<quinn::ClientConfig> {
     };
     let _ = peer_cfg_builder
         .add_certificate_authority(peer_cert)
-        .map_err(|_| QuicP2pError::AddCertificateError)?;
+        .map_err(|_| QuicP2pError::WebPki)?;
 
     Ok(peer_cfg_builder.build())
 }

--- a/src/peer_config.rs
+++ b/src/peer_config.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use crate::context::ctx;
-use crate::error::Error;
+use crate::error::QuicP2pError;
 use crate::R;
 use std::sync::Arc;
 
@@ -30,7 +30,7 @@ pub fn new_client_cfg(peer_cert_der: &[u8]) -> R<quinn::ClientConfig> {
     // itself is private. Hence using this workaround to collect it via `format!`. Ideally should
     // be just convertible inside quick_error as usual with other errors.
     let peer_cert = quinn::Certificate::from_der(peer_cert_der)
-        .map_err(|e| Error::CertificateParseError(format!("{:?}, {}", e, e)))?;
+        .map_err(|_| QuicP2pError::CertificateParseError)?;
 
     let mut peer_cfg_builder = {
         let mut client_cfg = quinn::ClientConfig::default();
@@ -40,7 +40,7 @@ pub fn new_client_cfg(peer_cert_der: &[u8]) -> R<quinn::ClientConfig> {
     };
     let _ = peer_cfg_builder
         .add_certificate_authority(peer_cert)
-        .map_err(|e| Error::AddCertificateError(format!("{:?} , {}", e, e)))?;
+        .map_err(|_| QuicP2pError::AddCertificateError)?;
 
     Ok(peer_cfg_builder.build())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@
 
 use crate::ctx_mut;
 use crate::dirs::Dirs;
-use crate::error::Error;
+use crate::error::QuicP2pError;
 use crate::event::Event;
 use log::debug;
 use serde::de::DeserializeOwned;
@@ -20,7 +20,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 /// Result used by `QuicP2p`.
-pub type R<T> = Result<T, Error>;
+pub type R<T> = Result<T, QuicP2pError>;
 /// Token accepted during sends and returned back to the user to help identify the context.
 pub type Token = u64;
 
@@ -42,7 +42,7 @@ pub fn connect_terminator() -> (ConnectTerminator, tokio::sync::mpsc::Receiver<(
 #[inline]
 pub fn project_dir() -> R<Dirs> {
     let dirs = directories::ProjectDirs::from("net", "MaidSafe", "quic-p2p")
-        .ok_or_else(|| Error::Io(::std::io::ErrorKind::NotFound.into()))?;
+        .ok_or_else(|| QuicP2pError::Io(::std::io::ErrorKind::NotFound.into()))?;
     Ok(Dirs::Desktop(dirs))
 }
 
@@ -87,7 +87,7 @@ pub fn bin_data_format(data: &[u8]) -> String {
 #[inline]
 pub fn handle_communication_err(
     peer_addr: SocketAddr,
-    e: &Error,
+    e: &QuicP2pError,
     details: &str,
     unsent_user_msg: Option<(bytes::Bytes, Token)>,
 ) {

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::{error::Error, utils, R};
+use crate::{error::QuicP2pError, utils, R};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::SocketAddr;
@@ -43,7 +43,7 @@ impl WireMsg {
         match msg_flag {
             Some(flag) if flag == USER_MSG_FLAG => Ok(WireMsg::UserMsg(From::from(raw))),
             Some(flag) if flag == !USER_MSG_FLAG => Ok(bincode::deserialize(&raw)?),
-            _x => Err(Error::InvalidWireMsgFlag),
+            _x => Err(QuicP2pError::InvalidWireMsgFlag),
         }
     }
 }


### PR DESCRIPTION
Replace quick_error with err_derive to be in line with quinn routing and also
derviced from std::Error
Removed format trick from CertificateError and created an issue in quinn to make tls
pub and allow access to those errors for composability.