### PR TITLE
Add full peer info to all events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 quinn = "^0.5.3"
-futures = "*"
+futures = "~0.3.1"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
 unwrap = "~1.2.1"
 bincode = "~1.1.2"

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -186,18 +186,18 @@ fn handle_qp2p_events(
         for event in event_rx.iter() {
             match event {
                 Event::ConnectedTo { peer } => unwrap!(peer_list.lock()).insert(peer),
-                Event::NewMessage { peer_addr, msg } => {
+                Event::NewMessage { peer, msg } => {
                     if msg.len() > 512 {
-                        println!("[{}] received bytes: {}", peer_addr, msg.len());
+                        println!("[{}] received bytes: {}", peer.peer_addr(), msg.len());
                     } else {
                         println!(
                             "[{}] {}",
-                            peer_addr,
+                            peer.peer_addr(),
                             unwrap!(String::from_utf8(msg.to_vec()))
                         );
                     }
                 }
-                event => println!("Unexpected Crust event: {:?}", event),
+                event => println!("Unexpected quic-p2p event: {:?}", event),
             }
         }
     })

--- a/examples/client_node.rs
+++ b/examples/client_node.rs
@@ -125,7 +125,7 @@ impl ClientNode {
         while let Ok(event) = self.event_rx.recv() {
             match event {
                 Event::ConnectedTo { peer } => self.on_connect(peer),
-                Event::NewMessage { peer_addr, msg } => self.on_msg_receive(peer_addr, msg),
+                Event::NewMessage { peer, msg } => self.on_msg_receive(peer.peer_addr(), msg),
                 event => warn!("Unexpected event: {:?}", event),
             }
         }

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-bytes = "~0.4.12"
+bytes = { version = "~0.4.12", features = ["serde"] }
 crossbeam-channel = "~0.3.8"
 fxhash = "~0.2.1"
 rand = "~0.7.2"

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -279,7 +279,7 @@ pub enum Event {
     /// Message received.
     NewMessage {
         /// Message sender.
-        peer_addr: SocketAddr,
+        peer: Peer,
         /// Message content.
         msg: Bytes,
     },

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -335,14 +335,15 @@ pub struct NodeInfo {
     /// Endpoint of the node
     pub peer_addr: SocketAddr,
     /// Certificate of the node
-    pub peer_cert_der: Vec<u8>,
+    #[structopt(parse(from_str))]
+    pub peer_cert_der: Bytes,
 }
 
 impl From<SocketAddr> for NodeInfo {
     fn from(addr: SocketAddr) -> Self {
         Self {
             peer_addr: addr,
-            peer_cert_der: vec![],
+            peer_cert_der: Bytes::new(),
         }
     }
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -265,7 +265,7 @@ pub enum Event {
     /// a failure beyond this point as a byzantine fault.
     SentUserMessage {
         /// Intended message recipient.
-        peer_addr: SocketAddr,
+        peer: Peer,
         /// Message content.
         msg: Bytes,
         /// Message Token

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -244,8 +244,8 @@ pub enum Event {
     },
     /// Connection to the given address failed.
     ConnectionFailure {
-        /// Address of the peer we attempted connecting to.
-        peer_addr: SocketAddr,
+        /// The peer we attempted connecting to.
+        peer: Peer,
         /// Error explaining connection failure.
         err: QuicP2pError,
     },

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -97,7 +97,7 @@ impl QuicP2p {
     /// and then send the message. This can be called multiple times while the peer is still being
     /// connected to - all the sends will be buffered until the peer is connected to.
     pub fn send(&mut self, peer: Peer, msg: Bytes, token: Token) {
-        self.inner.borrow_mut().send(peer.peer_addr(), msg, token)
+        self.inner.borrow_mut().send(peer, msg, token)
     }
 
     /// Get our connection info to give to others for them to connect to us
@@ -252,7 +252,7 @@ pub enum Event {
     /// Message sent by us but not delivered due to connection drop.
     UnsentUserMessage {
         /// Intended message recipient.
-        peer_addr: SocketAddr,
+        peer: Peer,
         /// Message content.
         msg: Bytes,
         /// Message Token

--- a/mock/src/node.rs
+++ b/mock/src/node.rs
@@ -210,9 +210,9 @@ impl Node {
             }),
             Packet::Disconnect => {
                 self.clear_pending_messages(src);
-                if self.peers.remove(&src).is_some() {
+                if let Some((_, peer_type)) = self.peers.remove(&src) {
                     self.fire_event(Event::ConnectionFailure {
-                        peer_addr: src,
+                        peer: to_peer(src, peer_type),
                         err: QuicP2pError,
                     })
                 }

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -549,7 +549,7 @@ impl Agent {
     ) {
         let (actual_addr, actual_msg, actual_id) = assert_match!(
             self.rx.try_recv(),
-            Ok(Event::SentUserMessage { peer_addr, msg, token }) => (peer_addr, msg, token)
+            Ok(Event::SentUserMessage { peer, msg, token }) => (peer.peer_addr(), msg, token)
         );
 
         assert_eq!(actual_addr, *dst_addr);

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -566,7 +566,7 @@ impl Agent {
     ) {
         let (actual_addr, actual_msg, actual_id) = assert_match!(
             self.rx.try_recv(),
-            Ok(Event::UnsentUserMessage { peer_addr, msg, token }) => (peer_addr, msg, token)
+            Ok(Event::UnsentUserMessage { peer, msg, token }) => (peer.peer_addr(), msg, token)
         );
 
         assert_eq!(actual_addr, *dst_addr);

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -525,7 +525,7 @@ impl Agent {
     fn expect_connection_failure(&self, addr: &SocketAddr) {
         let actual_addr = assert_match!(
             self.rx.try_recv(),
-            Ok(Event::ConnectionFailure { peer_addr, .. }) => peer_addr
+            Ok(Event::ConnectionFailure { peer, .. }) => peer.peer_addr()
         );
         assert_eq!(actual_addr, *addr);
     }

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -534,7 +534,7 @@ impl Agent {
     fn expect_new_message(&self, src_addr: &SocketAddr, expected_msg: &Bytes) {
         let (actual_addr, actual_msg) = assert_match!(
             self.rx.try_recv(),
-            Ok(Event::NewMessage { peer_addr, msg }) => (peer_addr, msg)
+            Ok(Event::NewMessage { peer, msg }) => (peer.peer_addr(), msg)
         );
 
         assert_eq!(actual_addr, *src_addr);
@@ -581,8 +581,8 @@ impl Agent {
 
     fn received_messages(&self, src_addr: &SocketAddr) -> FxHashSet<Bytes> {
         let mut received_messages = FxHashSet::default();
-        while let Ok(Event::NewMessage { peer_addr, msg }) = self.rx.try_recv() {
-            assert_eq!(peer_addr, *src_addr);
+        while let Ok(Event::NewMessage { peer, msg }) = self.rx.try_recv() {
+            assert_eq!(peer.peer_addr(), *src_addr);
             let _ = received_messages.insert(msg);
         }
         received_messages

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -35,6 +35,7 @@ pub fn start() {
 mod tests {
     use crate::test_utils::new_random_qp2p;
     use crate::{Builder, Config, Event, NodeInfo, OurType, QuicP2p};
+    use bytes::Bytes;
     use crossbeam_channel as mpmc;
     use std::collections::{HashSet, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -301,7 +302,7 @@ mod tests {
     fn node_will_report_failure_when_bootstrap_cache_and_hard_coded_contacts_are_invalid() {
         let dummy_peer_info = NodeInfo {
             peer_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 37692)),
-            peer_cert_der: vec![1, 2, 3],
+            peer_cert_der: Bytes::from_static(&[1, 2, 3]),
         };
         let (mut peer, ev_rx) = {
             let mut hcc = HashSet::new();

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -479,8 +479,10 @@ fn handle_user_msg(
     bootstrap_cache: &mut BootstrapCache,
     we_contacted_peer: bool,
 ) {
-    let peer_addr = peer.peer_addr();
-    let new_msg = Event::NewMessage { peer_addr, msg };
+    let new_msg = Event::NewMessage {
+        peer: peer.clone(),
+        msg,
+    };
     if let Err(e) = event_tx.send(new_msg) {
         info!("Could not dispatch incoming user message: {:?}", e);
     }

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -409,7 +409,7 @@ fn handle_rx_handshake(peer_addr: SocketAddr, handshake: Handshake) {
     })
 }
 
-fn handle_rx_cert(peer_addr: SocketAddr, peer_cert_der: Vec<u8>) {
+fn handle_rx_cert(peer_addr: SocketAddr, peer_cert_der: Bytes) {
     let node_info = NodeInfo {
         peer_addr,
         peer_cert_der,

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -541,8 +541,8 @@ mod tests {
 
         // The connection should fail because we don't allow bi-directional streams
         match rx0.recv() {
-            Ok(Event::ConnectionFailure { peer_addr, err }) => {
-                assert_eq!(peer_addr, qp2p1_info.peer_addr);
+            Ok(Event::ConnectionFailure { peer, err }) => {
+                assert_eq!(peer.peer_addr(), qp2p1_info.peer_addr);
                 assert_eq!(
                     format!("{}", err),
                     format!("{}", QuicP2pError::ConnectionCancelled)

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use crate::utils;
 use crate::{NodeInfo, R};
 use base64;
 use bincode;
+use bytes::Bytes;
 use log::{trace, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -111,9 +112,9 @@ impl Config {
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SerialisableCertificate {
     /// DER encoded certificate
-    pub cert_der: Vec<u8>,
+    pub cert_der: Bytes,
     /// DER encoded private key
-    pub key_der: Vec<u8>,
+    pub key_der: Bytes,
 }
 
 impl SerialisableCertificate {
@@ -139,8 +140,8 @@ impl Default for SerialisableCertificate {
         ]));
 
         Self {
-            cert_der: unwrap!(cert.serialize_der()),
-            key_der: cert.serialize_private_key_der(),
+            cert_der: unwrap!(cert.serialize_der()).into(),
+            key_der: cert.serialize_private_key_der().into(),
         }
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -97,7 +97,10 @@ pub fn connect_to(
                     },
                     // New connection
                     new_peer_conn_res = connecting.fuse() => {
-                        handle_new_connection_res(peer_addr, new_peer_conn_res);
+                        handle_new_connection_res(
+                            peer_addr,
+                            new_peer_conn_res
+                        );
                     },
                 }
             });
@@ -150,10 +153,10 @@ fn handle_new_connection_res(
         };
 
         let mut to_peer_prev = mem::take(&mut conn.to_peer);
-        let (peer_cert_der, pending_sends) = match to_peer_prev {
+        let (peer_cert_der, pending_sends) = match &mut to_peer_prev {
             ToPeer::Initiated {
-                ref mut peer_cert_der,
-                ref mut pending_sends,
+                peer_cert_der,
+                pending_sends,
                 ..
             } => (mem::take(peer_cert_der), mem::take(pending_sends)),
             // TODO analyse if this is actually reachable in some wierd case where things were in

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -11,9 +11,9 @@ use crate::connection::QConn;
 use crate::event::Event;
 use crate::utils::{ConnectTerminator, Token};
 use crate::wire_msg::WireMsg;
+use bytes::Bytes;
 use crossbeam_channel as mpmc;
-use std::fmt;
-use std::net::SocketAddr;
+use std::{fmt, net::SocketAddr};
 
 /// Represent various stages of connection from us to the peer.
 pub enum ToPeer {
@@ -22,12 +22,12 @@ pub enum ToPeer {
     Initiated {
         terminator: ConnectTerminator,
         peer_addr: SocketAddr,
-        peer_cert_der: Vec<u8>,
+        peer_cert_der: Bytes,
         pending_sends: Vec<(WireMsg, Token)>,
         event_tx: mpmc::Sender<Event>,
     },
     Established {
-        peer_cert_der: Vec<u8>,
+        peer_cert_der: Bytes,
         q_conn: QConn,
     },
 }

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -7,10 +7,13 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::connection::QConn;
-use crate::event::Event;
-use crate::utils::{ConnectTerminator, Token};
-use crate::wire_msg::WireMsg;
+use crate::{
+    connection::QConn,
+    event::Event,
+    peer::{NodeInfo, Peer},
+    utils::{ConnectTerminator, Token},
+    wire_msg::WireMsg,
+};
 use bytes::Bytes;
 use crossbeam_channel as mpmc;
 use std::{fmt, net::SocketAddr};
@@ -97,6 +100,7 @@ impl Drop for ToPeer {
             ToPeer::Initiated {
                 terminator,
                 peer_addr,
+                peer_cert_der,
                 pending_sends,
                 event_tx,
                 ..
@@ -108,7 +112,12 @@ impl Drop for ToPeer {
                     // error out
                     if let WireMsg::UserMsg(msg) = wire_msg {
                         let _ = event_tx.send(Event::UnsentUserMessage {
-                            peer_addr: *peer_addr,
+                            peer: Peer::Node {
+                                node_info: NodeInfo {
+                                    peer_addr: *peer_addr,
+                                    peer_cert_der: peer_cert_der.clone(),
+                                },
+                            },
                             msg,
                             token,
                         });

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -68,6 +68,15 @@ impl ToPeer {
             false
         }
     }
+
+    pub fn peer_cert_der(&self) -> Option<&Bytes> {
+        match self {
+            Self::Initiated { peer_cert_der, .. } | Self::Established { peer_cert_der, .. } => {
+                Some(peer_cert_der)
+            }
+            Self::NoConnection | Self::NotNeeded => None,
+        }
+    }
 }
 
 impl Default for ToPeer {

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -92,13 +92,13 @@ impl fmt::Debug for ToPeer {
 
 impl Drop for ToPeer {
     fn drop(&mut self) {
-        match *self {
+        match self {
             ToPeer::NotNeeded | ToPeer::NoConnection | ToPeer::Established { .. } => {}
             ToPeer::Initiated {
-                ref mut terminator,
-                ref peer_addr,
-                ref mut pending_sends,
-                ref event_tx,
+                terminator,
+                peer_addr,
+                pending_sends,
+                event_tx,
                 ..
             } => {
                 let _ = terminator.try_send(());

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use crate::error::QuicP2pError;
 use crate::{utils, NodeInfo, Peer};
-use std::{fmt, net::SocketAddr};
+use std::fmt;
 use utils::Token;
 
 /// QuicP2p Events to the user
@@ -15,8 +15,8 @@ pub enum Event {
     },
     /// Connection to this peer failed.
     ConnectionFailure {
-        /// Peer address.
-        peer_addr: SocketAddr,
+        /// Peer.
+        peer: Peer,
         /// Error explaining connection failure.
         err: QuicP2pError,
     },
@@ -62,10 +62,11 @@ impl fmt::Display for Event {
             Event::BootstrappedTo { node } => {
                 write!(f, "Event::BootstrappedTo {{ node: {} }}", node)
             }
-            Event::ConnectionFailure { peer_addr, err } => write!(
+            Event::ConnectionFailure { peer, err } => write!(
                 f,
-                "Event::ConnectionFailure {{ peer_addr: {}, err: {} }}",
-                peer_addr, err
+                "Event::ConnectionFailure {{ peer: {}, err: {} }}",
+                peer.peer_addr(),
+                err
             ),
             Event::SentUserMessage { peer, msg, token } => write!(
                 f,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,6 @@
 use crate::error::QuicP2pError;
 use crate::{utils, NodeInfo, Peer};
-use std::fmt;
-use std::net::SocketAddr;
+use std::{fmt, net::SocketAddr};
 use utils::Token;
 
 /// QuicP2p Events to the user
@@ -46,8 +45,8 @@ pub enum Event {
     },
     /// A new message was received from this peer.
     NewMessage {
-        /// Sending peer address.
-        peer_addr: SocketAddr,
+        /// Sending peer.
+        peer: Peer,
         /// The new message.
         msg: bytes::Bytes,
     },
@@ -58,23 +57,20 @@ pub enum Event {
 
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Event::BootstrapFailure => write!(f, "Event::BootstrapFailure"),
-            Event::BootstrappedTo { ref node } => {
+            Event::BootstrappedTo { node } => {
                 write!(f, "Event::BootstrappedTo {{ node: {} }}", node)
             }
-            Event::ConnectionFailure {
-                ref peer_addr,
-                ref err,
-            } => write!(
+            Event::ConnectionFailure { peer_addr, err } => write!(
                 f,
                 "Event::ConnectionFailure {{ peer_addr: {}, err: {} }}",
                 peer_addr, err
             ),
             Event::SentUserMessage {
-                ref peer_addr,
-                ref msg,
-                ref token,
+                peer_addr,
+                msg,
+                token,
             } => write!(
                 f,
                 "Event::SentUserMessage {{ peer_addr: {}, msg: {}, token: {} }}",
@@ -83,9 +79,9 @@ impl fmt::Display for Event {
                 token
             ),
             Event::UnsentUserMessage {
-                ref peer_addr,
-                ref msg,
-                ref token,
+                peer_addr,
+                msg,
+                token,
             } => write!(
                 f,
                 "Event::UnsentUserMessage {{ peer_addr: {}, msg: {}, token: {} }}",
@@ -93,14 +89,11 @@ impl fmt::Display for Event {
                 utils::bin_data_format(&*msg),
                 token
             ),
-            Event::ConnectedTo { ref peer } => write!(f, "Event::ConnectedTo {{ peer: {} }}", peer),
-            Event::NewMessage {
-                ref peer_addr,
-                ref msg,
-            } => write!(
+            Event::ConnectedTo { peer } => write!(f, "Event::ConnectedTo {{ peer: {} }}", peer),
+            Event::NewMessage { peer, msg } => write!(
                 f,
-                "Event::NewMessage {{ peer_addr: {}, msg: {} }}",
-                peer_addr,
+                "Event::NewMessage {{ peer: {}, msg: {} }}",
+                peer.peer_addr(),
                 utils::bin_data_format(&*msg)
             ),
             Event::Finish => write!(f, "Event::Finish"),

--- a/src/event.rs
+++ b/src/event.rs
@@ -31,8 +31,8 @@ pub enum Event {
     },
     /// The given message was not sent to this peer.
     UnsentUserMessage {
-        /// Peer address.
-        peer_addr: SocketAddr,
+        /// Peer.
+        peer: Peer,
         /// Unsent message.
         msg: bytes::Bytes,
         /// Token, originally given by the user, for context.
@@ -74,14 +74,10 @@ impl fmt::Display for Event {
                 utils::bin_data_format(&*msg),
                 token
             ),
-            Event::UnsentUserMessage {
-                peer_addr,
-                msg,
-                token,
-            } => write!(
+            Event::UnsentUserMessage { peer, msg, token } => write!(
                 f,
-                "Event::UnsentUserMessage {{ peer_addr: {}, msg: {}, token: {} }}",
-                peer_addr,
+                "Event::UnsentUserMessage {{ peer: {}, msg: {}, token: {} }}",
+                peer.peer_addr(),
                 utils::bin_data_format(&*msg),
                 token
             ),

--- a/src/event.rs
+++ b/src/event.rs
@@ -22,8 +22,8 @@ pub enum Event {
     },
     /// The given message was successfully sent to this peer.
     SentUserMessage {
-        /// Peer address.
-        peer_addr: SocketAddr,
+        /// Peer.
+        peer: Peer,
         /// Sent message.
         msg: bytes::Bytes,
         /// Token, originally given by the user, for context.
@@ -67,14 +67,10 @@ impl fmt::Display for Event {
                 "Event::ConnectionFailure {{ peer_addr: {}, err: {} }}",
                 peer_addr, err
             ),
-            Event::SentUserMessage {
-                peer_addr,
-                msg,
-                token,
-            } => write!(
+            Event::SentUserMessage { peer, msg, token } => write!(
                 f,
-                "Event::SentUserMessage {{ peer_addr: {}, msg: {}, token: {} }}",
-                peer_addr,
+                "Event::SentUserMessage {{ peer: {}, msg: {}, token: {} }}",
+                peer.peer_addr(),
                 utils::bin_data_format(&*msg),
                 token
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,12 +553,8 @@ mod tests {
             x => panic!("Received unexpected event: {:?}", x),
         }
         match unwrap!(rx2.recv()) {
-            Event::SentUserMessage {
-                peer_addr,
-                msg,
-                token,
-            } => {
-                assert_eq!(peer_addr, qp2p1_info.peer_addr);
+            Event::SentUserMessage { peer, msg, token } => {
+                assert_eq!(peer.peer_addr(), qp2p1_info.peer_addr);
                 assert_eq!(msg, data);
                 assert_eq!(token, TOKEN);
             }
@@ -632,15 +628,11 @@ mod tests {
                                 );
                             }
                         }
-                        Ok(Event::SentUserMessage {
-                            peer_addr,
-                            msg,
-                            token,
-                        }) => {
+                        Ok(Event::SentUserMessage { peer, msg, token }) => {
                             if rxd_sent_msg_event {
                                 panic!("Should have received sent message event only once !");
                             }
-                            assert_eq!(peer_addr, qp2p1_addr);
+                            assert_eq!(peer.peer_addr(), qp2p1_addr);
                             assert_eq!(msg, msg_to_qp2p1_clone0);
                             assert_eq!(token, TEST_TOKEN0);
                             rxd_sent_msg_event = true;
@@ -673,12 +665,12 @@ mod tests {
                         assert_eq!(peer.peer_addr(), qp2p0_addr);
                         assert_eq!(msg, msg_to_qp2p1_clone1);
                     }
-                    Ok(Event::SentUserMessage { peer_addr, token, .. }) => {
+                    Ok(Event::SentUserMessage { peer, token, .. }) => {
                         if count_of_rxd_sent_msgs >=3 {
                             panic!("Only sent 3 msgs, so cannot rx send success for more than those
                                    !");
                         }
-                        assert_eq!(peer_addr, qp2p0_addr);
+                        assert_eq!(peer.peer_addr(), qp2p0_addr);
                         assert_eq!(token, TEST_TOKEN1);
                         count_of_rxd_sent_msgs += 1;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,8 +546,8 @@ mod tests {
             x => panic!("Received unexpected event: {:?}", x),
         }
         match unwrap!(rx1.recv()) {
-            Event::NewMessage { peer_addr, msg } => {
-                assert_eq!(peer_addr, qp2p2_info.peer_addr);
+            Event::NewMessage { peer, msg } => {
+                assert_eq!(peer.peer_addr(), qp2p2_info.peer_addr);
                 assert_eq!(msg, data);
             }
             x => panic!("Received unexpected event: {:?}", x),
@@ -615,17 +615,21 @@ mod tests {
                 let mut rxd_sent_msg_event = false;
                 for i in 0..4 {
                     match rx0.recv() {
-                        Ok(Event::NewMessage { peer_addr, msg }) => {
-                            assert_eq!(peer_addr, qp2p1_addr);
+                        Ok(Event::NewMessage { peer, msg }) => {
+                            assert_eq!(peer.peer_addr(), qp2p1_addr);
                             if i != 3 {
                                 assert!(
                                     msg == small_msg0_to_qp2p0_clone
                                         || msg == small_msg1_to_qp2p0_clone
                                 );
-                                info!("Smaller message {:?} rxd from {}", &*msg, peer_addr)
+                                info!("Smaller message {:?} rxd from {}", &*msg, peer.peer_addr())
                             } else {
                                 assert_eq!(msg, big_msg_to_qp2p0_clone);
-                                info!("Big message of size {} rxd from {}", msg.len(), peer_addr);
+                                info!(
+                                    "Big message of size {} rxd from {}",
+                                    msg.len(),
+                                    peer.peer_addr()
+                                );
                             }
                         }
                         Ok(Event::SentUserMessage {
@@ -665,8 +669,8 @@ mod tests {
                 let mut count_of_rxd_sent_msgs: u8 = 0;
                 for _ in 0..4 {
                 match rx1.recv() {
-                    Ok(Event::NewMessage { peer_addr, msg }) => {
-                        assert_eq!(peer_addr, qp2p0_addr);
+                    Ok(Event::NewMessage { peer, msg }) => {
+                        assert_eq!(peer.peer_addr(), qp2p0_addr);
                         assert_eq!(msg, msg_to_qp2p1_clone1);
                     }
                     Ok(Event::SentUserMessage { peer_addr, token, .. }) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use utils::{Token, R};
 
 use crate::wire_msg::WireMsg;
 use bootstrap_cache::BootstrapCache;
+use bytes::Bytes;
 use context::{ctx, ctx_mut, initialise_ctx, Context};
 use crossbeam_channel as mpmc;
 use event_loop::EventLoop;
@@ -232,7 +233,7 @@ impl QuicP2p {
     ///
     /// `token` is supplied by the user code and will be returned with the message to help identify
     /// the context, for successful or unsuccessful sends.
-    pub fn send(&mut self, peer: Peer, msg: bytes::Bytes, token: Token) {
+    pub fn send(&mut self, peer: Peer, msg: Bytes, token: Token) {
         self.el.post(move || {
             let peer_addr = peer.peer_addr();
 
@@ -433,7 +434,7 @@ impl QuicP2p {
         Ok(())
     }
 
-    fn our_certificate_der(&mut self) -> Vec<u8> {
+    fn our_certificate_der(&mut self) -> Bytes {
         let (tx, rx) = mpsc::channel();
 
         self.el.post(move || {
@@ -780,7 +781,9 @@ mod tests {
             .build());
         malicious_client.send_wire_msg(
             qp2p0_info.clone().into(),
-            WireMsg::Handshake(Handshake::Node { cert_der: vec![] }),
+            WireMsg::Handshake(Handshake::Node {
+                cert_der: Bytes::new(),
+            }),
             0,
         );
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -8,9 +8,9 @@
 // Software.
 
 use crate::utils;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::net::SocketAddr;
+use std::{fmt, net::SocketAddr};
 
 /// Representation of a peer to us.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
@@ -69,7 +69,7 @@ pub struct NodeInfo {
     /// Endpoint of the node
     pub peer_addr: SocketAddr,
     /// Certificate of the node
-    pub peer_cert_der: Vec<u8>,
+    pub peer_cert_der: Bytes,
 }
 
 impl Into<Peer> for NodeInfo {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,10 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::ctx_mut;
-use crate::dirs::Dirs;
-use crate::error::QuicP2pError;
-use crate::event::Event;
+use crate::{ctx_mut, dirs::Dirs, error::QuicP2pError, event::Event, peer::Peer};
 use log::debug;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -109,14 +106,10 @@ pub fn handle_communication_err(
 
 /// Handle successful sends. Currently a NoOp for non-user-messages (i.e., internal messages).
 #[inline]
-pub fn handle_send_success(peer_addr: SocketAddr, sent_user_msg: Option<(bytes::Bytes, Token)>) {
+pub fn handle_send_success(peer: Peer, sent_user_msg: Option<(bytes::Bytes, Token)>) {
     ctx_mut(|c| {
         if let Some((msg, token)) = sent_user_msg {
-            let _ = c.event_tx.send(Event::SentUserMessage {
-                peer_addr,
-                msg,
-                token,
-            });
+            let _ = c.event_tx.send(Event::SentUserMessage { peer, msg, token });
         }
     });
 }

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -8,9 +8,9 @@
 // Software.
 
 use crate::{error::QuicP2pError, utils, R};
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::net::SocketAddr;
+use std::{fmt, net::SocketAddr};
 use unwrap::unwrap;
 
 /// Final type serialised and sent on the wire by QuicP2p
@@ -19,13 +19,13 @@ pub enum WireMsg {
     Handshake(Handshake),
     EndpointEchoReq,
     EndpointEchoResp(SocketAddr),
-    UserMsg(bytes::Bytes),
+    UserMsg(Bytes),
 }
 
 const USER_MSG_FLAG: u8 = 0;
 
-impl Into<(bytes::Bytes, u8)> for WireMsg {
-    fn into(self) -> (bytes::Bytes, u8) {
+impl Into<(Bytes, u8)> for WireMsg {
+    fn into(self) -> (Bytes, u8) {
         match self {
             WireMsg::UserMsg(ref m) => (m.clone(), USER_MSG_FLAG),
             _ => (
@@ -74,7 +74,7 @@ impl fmt::Display for WireMsg {
 pub enum Handshake {
     /// The connecting peer is a node. Certificate is needed for allowing connection back to the
     /// peer
-    Node { cert_der: Vec<u8> },
+    Node { cert_der: Bytes },
     /// The connecting peer is a client. No need for a reverse connection.
     Client,
 }


### PR DESCRIPTION
This PR changes `Event` so it always includes the full peer info instead of just their socket address. This makes life easier for the consumers of this library because they no longer need to maintain separate mapping between socket address and peer info.

It also changes the representation of the serialized certificate from `Vec<u8>` to `Bytes` which makes is cheap to clone. 