### PR TITLE
Remove peer certificates 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ serde = { version = "~1.0.91", features = ["derive"] }
 serde_json = "~1.0.39"
 structopt = "~0.2.15"
 rcgen = "~0.7.0"
-rustls = "~0.16.0"
+rustls = { version = "~0.16.0", features = ["dangerous_configuration"] }
 log = "~0.4.6"
 base64 = "~0.10.1"
 err-derive = "^0.2.2"
 derive_more = "^0.99.2"
+webpki = "~0.21.2"
 
 [dev-dependencies]
 clap = "~2.32.0"

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -205,17 +205,14 @@ fn handle_qp2p_events(
 
 fn print_ourinfo(qp2p: &mut QuicP2p) {
     let ourinfo: Peer = match qp2p.our_connection_info() {
-        Ok(ourinfo) => ourinfo.into(),
+        Ok(addr) => Peer::Node(addr),
         Err(e) => {
             println!("Error getting ourinfo: {}", e);
             return;
         }
     };
 
-    println!(
-        "Our info:\n\n{}\n",
-        serde_json::to_string(&ourinfo).unwrap()
-    );
+    println!("Our info: {}", ourinfo);
 }
 
 fn print_logo() {

--- a/examples/client_node.rs
+++ b/examples/client_node.rs
@@ -25,7 +25,7 @@ use crossbeam_channel as mpmc;
 use env_logger;
 use log::{debug, error, info, warn};
 use quic_p2p::{Builder, Config, Event, Peer, QuicP2p};
-use rand::{self, seq::IteratorRandom, RngCore};
+use rand::{self, distributions::Standard, seq::IteratorRandom, Rng};
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -225,10 +225,9 @@ fn hash_correct(data: &[u8]) -> bool {
     encoded_hash == actual_hash
 }
 
-#[allow(unsafe_code)]
 fn random_vec(size: usize) -> Vec<u8> {
-    let mut ret = Vec::with_capacity(size);
-    unsafe { ret.set_len(size) };
-    rand::thread_rng().fill_bytes(&mut ret[..]);
-    ret
+    rand::thread_rng()
+        .sample_iter(&Standard)
+        .take(size)
+        .collect()
 }

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -125,7 +125,7 @@ impl BootstrapCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{rand_node_addr, test_dirs};
+    use crate::test_utils::{make_node_addr, rand_node_addr, test_dirs};
     use unwrap::unwrap;
 
     mod add_peer {
@@ -166,14 +166,16 @@ mod tests {
         #[test]
         fn it_caps_cache_size() {
             let dirs = test_dirs();
+            let port_base = 5000;
+
             let mut cache = unwrap!(BootstrapCache::new(Default::default(), Some(&dirs)));
 
-            for _ in 0..MAX_CACHE_SIZE {
-                cache.add_peer(rand_node_addr());
+            for i in 0..MAX_CACHE_SIZE {
+                cache.add_peer(make_node_addr(port_base + i as u16));
             }
             assert_eq!(cache.peers.len(), MAX_CACHE_SIZE);
 
-            cache.add_peer(rand_node_addr());
+            cache.add_peer(make_node_addr(port_base + MAX_CACHE_SIZE as u16));
             assert_eq!(cache.peers.len(), MAX_CACHE_SIZE);
         }
     }

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -349,8 +349,8 @@ pub fn dispatch_wire_msg(
 }
 
 fn handle_rx_handshake(peer_addr: SocketAddr, handshake: Handshake) {
-    if let Handshake::Node { cert_der } = handshake {
-        return handle_rx_cert(peer_addr, cert_der);
+    if let Handshake::Node = handshake {
+        return handle_rx_handshake_from_node(peer_addr);
     }
 
     // Handshake from a client
@@ -389,7 +389,7 @@ fn handle_rx_handshake(peer_addr: SocketAddr, handshake: Handshake) {
     })
 }
 
-fn handle_rx_cert(peer_addr: SocketAddr, _peer_cert_der: Bytes) {
+fn handle_rx_handshake_from_node(peer_addr: SocketAddr) {
     let reverse_connect_to_peer = ctx_mut(|c| {
         // FIXME: Dropping the connection most probably will not drop the incoming stream
         // and then if you get a message on it you might still end up here without an entry

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,17 +10,15 @@
 use crate::dirs::Dirs;
 use crate::error::QuicP2pError;
 use crate::utils;
-use crate::{NodeInfo, R};
+use crate::R;
 use base64;
 use bincode;
 use bytes::Bytes;
 use log::{trace, warn};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::net::IpAddr;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::{fmt, fs, io};
+use std::{
+    collections::HashSet, fmt, fs, io, net::IpAddr, net::SocketAddr, path::PathBuf, str::FromStr,
+};
 use structopt::StructOpt;
 use unwrap::unwrap;
 
@@ -35,7 +33,7 @@ pub struct Config {
         default_value = "[]",
         parse(try_from_str = "serde_json::from_str")
     )]
-    pub hard_coded_contacts: HashSet<NodeInfo>,
+    pub hard_coded_contacts: HashSet<SocketAddr>,
     /// Port we want to reserve for QUIC. If none supplied we'll use the OS given random port.
     #[structopt(short, long)]
     pub port: Option<u16>,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -163,9 +163,7 @@ fn handle_new_connection_res(
                 communicate::write_to_peer_connection(
                     Peer::Node(peer_addr),
                     &q_conn,
-                    WireMsg::Handshake(Handshake::Node {
-                        cert_der: c.our_complete_cert.cert_der.clone(),
-                    }),
+                    WireMsg::Handshake(Handshake::Node),
                     0,
                 );
             }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -14,7 +14,6 @@ use crate::connection::{
 use crate::context::ctx_mut;
 use crate::error::QuicP2pError;
 use crate::event::Event;
-use crate::peer_config;
 use crate::utils::{self, Token};
 use crate::wire_msg::{Handshake, WireMsg};
 use crate::{communicate, Peer, R};
@@ -33,8 +32,6 @@ pub fn connect_to(
     bootstrap_group_maker: Option<&BootstrapGroupMaker>,
 ) -> R<()> {
     debug!("Connecting to {}", node_addr);
-
-    let peer_cfg = peer_config::new_client_cfg();
 
     let r = ctx_mut(|c| {
         let event_tx = c.event_tx.clone();
@@ -76,9 +73,9 @@ pub fn connect_to(
                 event_tx,
             };
 
-            let connecting = c
-                .quic_ep()
-                .connect_with(peer_cfg, &node_addr, "MaidSAFE.net")?;
+            let connecting =
+                c.quic_ep()
+                    .connect_with(c.quic_client_cfg.clone(), &node_addr, "MaidSAFE.net")?;
 
             let _ = tokio::spawn(async move {
                 select! {

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,11 +83,10 @@ pub struct Context {
     pub our_ext_addr_tx: Option<mpsc::Sender<SocketAddr>>,
     pub our_complete_cert: SerialisableCertificate,
     pub max_msg_size_allowed: usize,
-    pub idle_timeout_msec: u64,
-    pub keep_alive_interval_msec: u32,
     pub our_type: OurType,
     pub bootstrap_cache: BootstrapCache,
     pub(crate) quic_ep: quinn::Endpoint,
+    pub(crate) quic_client_cfg: quinn::ClientConfig,
 }
 
 impl Context {
@@ -96,11 +95,10 @@ impl Context {
         event_tx: mpmc::Sender<Event>,
         our_complete_cert: SerialisableCertificate,
         max_msg_size_allowed: usize,
-        idle_timeout_msec: u64,
-        keep_alive_interval_msec: u32,
         our_type: OurType,
         bootstrap_cache: BootstrapCache,
         quic_ep: quinn::Endpoint,
+        quic_client_cfg: quinn::ClientConfig,
     ) -> Self {
         Self {
             event_tx,
@@ -108,11 +106,10 @@ impl Context {
             our_ext_addr_tx: Default::default(),
             our_complete_cert,
             max_msg_size_allowed,
-            idle_timeout_msec,
-            keep_alive_interval_msec,
             our_type,
             bootstrap_cache,
             quic_ep,
+            quic_client_cfg,
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use crate::error::QuicP2pError;
-use crate::{utils, NodeInfo, Peer};
-use std::fmt;
+use crate::{utils, Peer};
+use std::{fmt, net::SocketAddr};
 use utils::Token;
 
 /// QuicP2p Events to the user
@@ -11,7 +11,7 @@ pub enum Event {
     /// Bootstrap connection to this node was successful.
     BootstrappedTo {
         /// Node information.
-        node: NodeInfo,
+        node: SocketAddr,
     },
     /// Connection to this peer failed.
     ConnectionFailure {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,9 +754,7 @@ mod tests {
             .build());
         malicious_client.send_wire_msg(
             Peer::Node(qp2p0_addr),
-            WireMsg::Handshake(Handshake::Node {
-                cert_der: Bytes::new(),
-            }),
+            WireMsg::Handshake(Handshake::Node),
             0,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,15 +405,17 @@ impl QuicP2p {
                 }
             };
 
+            let client_cfg =
+                peer_config::new_client_cfg(idle_timeout_msec, keep_alive_interval_msec);
+
             let ctx = Context::new(
                 tx,
                 our_complete_cert,
                 max_msg_size_allowed,
-                idle_timeout_msec,
-                keep_alive_interval_msec,
                 our_type,
                 bootstrap_cache,
                 ep,
+                client_cfg,
             );
             initialise_ctx(ctx);
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -7,84 +7,32 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::utils;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::{fmt, net::SocketAddr};
 
 /// Representation of a peer to us.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub enum Peer {
-    /// Stores Node information.
-    Node {
-        /// Information needed to connect to a node.
-        node_info: NodeInfo,
-    },
-    /// Stores client information.
-    Client {
-        /// Address of the client reaching us.
-        peer_addr: SocketAddr,
-    },
+    /// Peer is a node.
+    Node(SocketAddr),
+    /// Peer is a client.
+    Client(SocketAddr),
 }
 
 impl Peer {
     /// Get peer's Endpoint
     pub fn peer_addr(&self) -> SocketAddr {
         match *self {
-            Peer::Node { ref node_info } => node_info.peer_addr,
-            Peer::Client { peer_addr } => peer_addr,
-        }
-    }
-
-    /// Get peer's Certificate
-    ///
-    /// If the peer was a node then the function returns the certificate used by it. For clients it
-    /// is not useful in our network to share certificates as we don't reverse connect to the
-    /// clients. Due to absence of the knowledge of client's certificate (as it's not exchanged in
-    /// handshake) this function retuns `None` for client peers.
-    pub fn peer_cert_der(&self) -> Option<&[u8]> {
-        match *self {
-            Peer::Node { ref node_info } => Some(&node_info.peer_cert_der),
-            Peer::Client { .. } => None,
+            Self::Node(addr) | Self::Client(addr) => addr,
         }
     }
 }
 
 impl fmt::Display for Peer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Peer::Node { ref node_info } => write!(f, "Peer::Node {{ node_info: {} }}", node_info),
-            Peer::Client { ref peer_addr } => {
-                write!(f, "Peer::Client {{ peer_addr: {} }}", peer_addr)
-            }
+        match self {
+            Self::Node(addr) => write!(f, "Peer::Node({})", addr),
+            Self::Client(addr) => write!(f, "Peer::Client({})", addr),
         }
-    }
-}
-
-/// Information for a peer of type `Peer::Node`.
-///
-/// This is a necessary information needed to connect to someone.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
-pub struct NodeInfo {
-    /// Endpoint of the node
-    pub peer_addr: SocketAddr,
-    /// Certificate of the node
-    pub peer_cert_der: Bytes,
-}
-
-impl Into<Peer> for NodeInfo {
-    fn into(self) -> Peer {
-        Peer::Node { node_info: self }
-    }
-}
-
-impl fmt::Display for NodeInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "NodeInfo {{ peer_addr: {}, peer_cert_der: {} }}",
-            self.peer_addr,
-            utils::bin_data_format(&self.peer_cert_der)
-        )
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -159,7 +159,10 @@ pub(crate) fn test_dirs() -> Dirs {
 
 pub(crate) fn rand_node_addr() -> SocketAddr {
     let mut rng = rand::thread_rng();
-    let port: u16 = rng.gen();
+    make_node_addr(rng.gen())
+}
+
+pub(crate) fn make_node_addr(port: u16) -> SocketAddr {
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::config::{Config, SerialisableCertificate};
+use crate::config::Config;
 use crate::connection::{Connection, FromPeer, QConn, ToPeer};
 use crate::context::ctx;
 use crate::context::Context;
@@ -15,7 +15,7 @@ use crate::dirs::{Dirs, OverRide};
 use crate::event::Event;
 use crate::utils::{Token, R};
 use crate::wire_msg::WireMsg;
-use crate::{communicate, Builder, NodeInfo, Peer, QuicP2p};
+use crate::{communicate, Builder, Peer, QuicP2p};
 use crossbeam_channel as mpmc;
 use futures::future::Future;
 use rand::Rng;
@@ -157,15 +157,10 @@ pub(crate) fn test_dirs() -> Dirs {
     Dirs::Overide(OverRide::new(&unwrap!(tmp_rand_dir().to_str())))
 }
 
-pub(crate) fn rand_node_info() -> NodeInfo {
-    let peer_cert_der = SerialisableCertificate::default().cert_der;
+pub(crate) fn rand_node_addr() -> SocketAddr {
     let mut rng = rand::thread_rng();
     let port: u16 = rng.gen();
-    let peer_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
-    NodeInfo {
-        peer_addr,
-        peer_cert_der,
-    }
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
 }
 
 fn tmp_rand_dir() -> PathBuf {
@@ -178,7 +173,7 @@ fn tmp_rand_dir() -> PathBuf {
 /// Creates a new `QuicP2p` instance for testing.
 pub(crate) fn new_random_qp2p(
     is_addr_unspecified: bool,
-    contacts: HashSet<NodeInfo>,
+    contacts: HashSet<SocketAddr>,
 ) -> (QuicP2p, mpmc::Receiver<Event>) {
     let (tx, rx) = mpmc::unbounded();
     let qp2p = {

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -72,9 +72,8 @@ impl fmt::Display for WireMsg {
 /// Depending on the handshake we will categorise the peer and give this information to the user.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Handshake {
-    /// The connecting peer is a node. Certificate is needed for allowing connection back to the
-    /// peer
-    Node { cert_der: Bytes },
+    /// The connecting peer is a node.
+    Node,
     /// The connecting peer is a client. No need for a reverse connection.
     Client,
 }
@@ -82,11 +81,7 @@ pub enum Handshake {
 impl fmt::Display for Handshake {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Handshake::Node { ref cert_der } => write!(
-                f,
-                "Handshake::Node {{ cert_der: {} }}",
-                utils::bin_data_format(cert_der)
-            ),
+            Handshake::Node => write!(f, "Handshake::Node",),
             Handshake::Client => write!(f, "Handshake::Client"),
         }
     }


### PR DESCRIPTION
Currently in order to establish secure connection to a node, we need to obtain their certificate via a side-channel and then pass it to quic-p2p in the `NodeInfo` struct. Quic-p2p then effectively creates a separate "certificate authority" for each node using this certificate. This is insecure and inconvenient. This PR removes this mechanism by effectively disabling any certificate validation. This makes the API simpler but requires the consumers of quic-p2p to handle any authentication themselves. 

At some point in the future we will reintroduce certificate validation back, but likely using a proper certification authority.