### PR TITLE
Take 2 channel one for client event one for node

### DIFF
--- a/examples/bootstrap_node.rs
+++ b/examples/bootstrap_node.rs
@@ -20,8 +20,7 @@
 mod common;
 use bincode;
 use bytes::Bytes;
-use common::Rpc;
-use crossbeam_channel as mpmc;
+use common::{new_unbounded_channels, Rpc};
 use env_logger;
 use log::{error, info, warn};
 use quic_p2p::{Builder, Config, Event, Peer};
@@ -49,7 +48,7 @@ fn main() -> Result<(), io::Error> {
     let bootstrap_node_config = BootstrapNodeConfig::from_args();
 
     // Initialise QuicP2p
-    let (ev_tx, ev_rx) = mpmc::unbounded();
+    let (ev_tx, ev_rx) = new_unbounded_channels();
 
     let mut qp2p = unwrap!(Builder::new(ev_tx)
         .with_config(bootstrap_node_config.quic_p2p_opts)

--- a/examples/client_node.rs
+++ b/examples/client_node.rs
@@ -19,9 +19,8 @@
 mod common;
 
 use bytes::Bytes;
-use common::Rpc;
+use common::{new_unbounded_channels, EventReceivers, Rpc};
 use crc::crc32;
-use crossbeam_channel as mpmc;
 use env_logger;
 use log::{debug, error, info, warn};
 use quic_p2p::{Builder, Config, Event, Peer, QuicP2p};
@@ -43,7 +42,7 @@ struct CliArgs {
 struct ClientNode {
     qp2p: QuicP2p,
     bootstrap_node_addr: SocketAddr,
-    event_rx: mpmc::Receiver<Event>,
+    event_rx: EventReceivers,
     /// Other nodes we will be communicating with.
     client_nodes: HashSet<SocketAddr>,
     our_addr: SocketAddr,
@@ -80,7 +79,7 @@ impl ClientNode {
             .choose(&mut rand::thread_rng())
             .ok_or_else(|| "No valid bootstrap node was provided.".to_string())?;
 
-        let (event_tx, event_rx) = mpmc::unbounded();
+        let (event_tx, event_rx) = new_unbounded_channels();
         let mut qp2p = unwrap!(Builder::new(event_tx).with_config(config).build());
 
         let large_msg = Bytes::from(random_data_with_hash(LARGE_MSG_SIZE));

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -7,7 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use quic_p2p::Peer;
+use crossbeam_channel as mpmc;
+use quic_p2p::{Event, EventSenders, Peer};
 use serde::{Deserialize, Serialize};
 
 /// Remote procedure call for our examples to communicate.
@@ -15,4 +16,32 @@ use serde::{Deserialize, Serialize};
 pub enum Rpc {
     /// Starts the connectivity and data exchange test between us and given QuicP2p peers.
     StartTest(Vec<Peer>),
+}
+
+/// Receivers side for events
+pub struct EventReceivers {
+    pub node_rx: mpmc::Receiver<Event>,
+    pub client_rx: mpmc::Receiver<Event>,
+}
+
+impl EventReceivers {
+    #[allow(unused)]
+    pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
+        self.node_rx.recv()
+    }
+
+    #[allow(unused)]
+    pub fn iter(&self) -> mpmc::Iter<Event> {
+        self.node_rx.iter()
+    }
+}
+
+/// Create channels for events
+pub fn new_unbounded_channels() -> (EventSenders, EventReceivers) {
+    let (client_tx, client_rx) = mpmc::unbounded();
+    let (node_tx, node_rx) = mpmc::unbounded();
+    (
+        EventSenders { node_tx, client_tx },
+        EventReceivers { node_rx, client_rx },
+    )
 }

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -35,9 +35,11 @@ pub struct QuicP2pError;
 /// Senders for node and client events
 #[derive(Clone)]
 pub struct EventSenders {
-    /// The client event sender
+    /// The event sender for events comming from clients.
     pub client_tx: Sender<Event>,
-    /// The node event sender
+    /// The event sender for events comming from nodes.
+    /// This also includes our own bootstrapping events `Event::BootstrapFailure`
+    /// and `Event::BootstrappedTo` as well as `Event::Finish`.
     pub node_tx: Sender<Event>,
 }
 

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -349,8 +349,8 @@ impl Peer {
 
     pub(crate) fn is_node(&self) -> bool {
         match *self {
-            Peer::Node { .. } => false,
-            Peer::Client { .. } => true,
+            Peer::Node { .. } => true,
+            Peer::Client { .. } => false,
         }
     }
 }

--- a/mock/src/node.rs
+++ b/mock/src/node.rs
@@ -8,10 +8,9 @@
 
 use super::{
     network::{Inner, Message, Packet, NETWORK},
-    Config, Event, OurType, Peer, QuicP2pError,
+    Config, Event, EventSenders, OurType, Peer, QuicP2pError,
 };
 use bytes::Bytes;
-use crossbeam_channel::Sender;
 // Note: using `FxHashMap` / `FxHashSet` because they don't use random state and thus guarantee
 // consistent iteration order (necessary for repeatable tests). Can't use `BTreeMap` / `BTreeSet`
 // because we key by `SocketAddr` which doesn't implement `Ord`.
@@ -21,7 +20,7 @@ use std::{cell::RefCell, net::SocketAddr, rc::Rc};
 pub(super) struct Node {
     network: Rc<RefCell<Inner>>,
     addr: SocketAddr,
-    event_tx: Sender<Event>,
+    event_tx: EventSenders,
     config: Config,
     peers: FxHashMap<SocketAddr, (ConnectionType, OurType)>,
     bootstrap_cache: FxHashSet<SocketAddr>,
@@ -30,7 +29,7 @@ pub(super) struct Node {
 }
 
 impl Node {
-    pub fn new(event_tx: Sender<Event>, config: Config) -> Rc<RefCell<Self>> {
+    pub fn new(event_tx: EventSenders, config: Config) -> Rc<RefCell<Self>> {
         let network = NETWORK.with(|network| {
             Rc::clone(
                 network

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -33,9 +33,8 @@ pub fn start() {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::new_random_qp2p;
+    use crate::test_utils::{new_random_qp2p, new_unbounded_channels, EventReceivers};
     use crate::{Builder, Config, Event, OurType, QuicP2p};
-    use crossbeam_channel as mpmc;
     use std::collections::{HashSet, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::thread;
@@ -133,7 +132,7 @@ mod tests {
             .collect();
 
         // Waiting for all nodes to start
-        let (ev_tx, ev_rx) = mpmc::unbounded();
+        let (ev_tx, ev_rx) = new_unbounded_channels();
         let mut bootstrapping_node = unwrap!(Builder::new(ev_tx)
             .with_config(Config {
                 port: Some(0),
@@ -176,7 +175,7 @@ mod tests {
         let mut hcc = HashSet::with_capacity(1);
         assert!(hcc.insert(bootstrap_ci));
 
-        let (ev_tx, ev_rx) = mpmc::unbounded();
+        let (ev_tx, ev_rx) = new_unbounded_channels();
         let mut bootstrap_client = unwrap!(Builder::new(ev_tx)
             .with_config(Config {
                 port: Some(0),
@@ -317,9 +316,9 @@ mod tests {
 
     fn test_peer_with_bootstrap_cache(
         mut cached_peers: Vec<SocketAddr>,
-    ) -> (QuicP2p, mpmc::Receiver<Event>) {
+    ) -> (QuicP2p, EventReceivers) {
         let cached_peers: VecDeque<_> = cached_peers.drain(..).collect();
-        let (ev_tx, ev_rx) = mpmc::unbounded();
+        let (ev_tx, ev_rx) = new_unbounded_channels();
         let builder = Builder::new(ev_tx)
             .with_config(Config {
                 port: Some(0),
@@ -331,7 +330,7 @@ mod tests {
     }
 
     /// Constructs a `QuicP2p` node with some sane defaults for testing.
-    fn test_node() -> (QuicP2p, mpmc::Receiver<Event>) {
+    fn test_node() -> (QuicP2p, EventReceivers) {
         test_peer_with_hcc(Default::default(), OurType::Node)
     }
 
@@ -339,8 +338,8 @@ mod tests {
     fn test_peer_with_hcc(
         hard_coded_contacts: HashSet<SocketAddr>,
         our_type: OurType,
-    ) -> (QuicP2p, mpmc::Receiver<Event>) {
-        let (ev_tx, ev_rx) = mpmc::unbounded();
+    ) -> (QuicP2p, EventReceivers) {
+        let (ev_tx, ev_rx) = new_unbounded_channels();
         let builder = Builder::new(ev_tx)
             .with_config(Config {
                 port: Some(0),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -12,8 +12,7 @@ pub use self::from_peer::FromPeer;
 pub use self::q_conn::QConn;
 pub use self::to_peer::ToPeer;
 
-use crate::{context::ctx_mut, error::QuicP2pError, event::Event, peer::Peer};
-use crossbeam_channel as mpmc;
+use crate::{context::ctx_mut, error::QuicP2pError, event::Event, peer::Peer, EventSenders};
 use futures::future::FutureExt;
 use log::trace;
 use std::{collections::hash_map::Entry, fmt, net::SocketAddr, time::Duration};
@@ -42,14 +41,14 @@ pub struct Connection {
     /// end of this connection.
     pub we_contacted_peer: bool,
     peer_addr: SocketAddr,
-    event_tx: mpmc::Sender<Event>,
+    event_tx: EventSenders,
 }
 
 impl Connection {
     /// New Connection with defaults
     pub fn new(
         peer_addr: SocketAddr,
-        event_tx: mpmc::Sender<Event>,
+        event_tx: EventSenders,
         bootstrap_group_ref: Option<BootstrapGroupRef>,
     ) -> Self {
         spawn_incomplete_conn_killer(peer_addr);

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -13,8 +13,8 @@ use crate::{
     peer::Peer,
     utils::{ConnectTerminator, Token},
     wire_msg::WireMsg,
+    EventSenders,
 };
-use crossbeam_channel as mpmc;
 use std::{fmt, net::SocketAddr};
 
 /// Represent various stages of connection from us to the peer.
@@ -25,7 +25,7 @@ pub enum ToPeer {
         terminator: ConnectTerminator,
         peer_addr: SocketAddr,
         pending_sends: Vec<(WireMsg, Token)>,
-        event_tx: mpmc::Sender<Event>,
+        event_tx: EventSenders,
     },
     Established {
         q_conn: QConn,

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,8 +10,7 @@
 use crate::bootstrap_cache::BootstrapCache;
 use crate::config::{OurType, SerialisableCertificate};
 use crate::connection::Connection;
-use crate::event::Event;
-use crossbeam_channel as mpmc;
+use crate::EventSenders;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -78,7 +77,7 @@ where
 /// The context to the event loop. This holds all the states that are necessary to be persistant
 /// between calls to poll the event loop for the next event.
 pub struct Context {
-    pub event_tx: mpmc::Sender<Event>,
+    pub event_tx: EventSenders,
     pub connections: HashMap<SocketAddr, Connection>,
     pub our_ext_addr_tx: Option<mpsc::Sender<SocketAddr>>,
     pub our_complete_cert: SerialisableCertificate,
@@ -92,7 +91,7 @@ pub struct Context {
 impl Context {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        event_tx: mpmc::Sender<Event>,
+        event_tx: EventSenders,
         our_complete_cert: SerialisableCertificate,
         max_msg_size_allowed: usize,
         our_type: OurType,

--- a/src/event.rs
+++ b/src/event.rs
@@ -55,6 +55,21 @@ pub enum Event {
     Finish,
 }
 
+impl Event {
+    pub(crate) fn is_node_event(&self) -> bool {
+        match self {
+            Event::BootstrapFailure => true,
+            Event::BootstrappedTo { .. } => true,
+            Event::ConnectionFailure { peer, .. }
+            | Event::SentUserMessage { peer, .. }
+            | Event::UnsentUserMessage { peer, .. }
+            | Event::ConnectedTo { peer }
+            | Event::NewMessage { peer, .. } => peer.is_node(),
+            Event::Finish => true,
+        }
+    }
+}
+
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@ pub const DEFAULT_PORT_TO_TRY: u16 = 443;
 #[derive(Clone)]
 pub struct EventSenders {
     /// The client event sender
-    #[allow(unused)]
     pub client_tx: mpmc::Sender<Event>,
     /// The node event sender
     pub node_tx: mpmc::Sender<Event>,
@@ -110,7 +109,11 @@ pub struct EventSenders {
 
 impl EventSenders {
     pub(crate) fn send(&self, event: Event) -> Result<(), mpmc::SendError<Event>> {
-        self.node_tx.send(event)
+        if event.is_node_event() {
+            self.node_tx.send(event)
+        } else {
+            self.client_tx.send(event)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,11 @@ pub const DEFAULT_PORT_TO_TRY: u16 = 443;
 /// Senders for node and client events
 #[derive(Clone)]
 pub struct EventSenders {
-    /// The client event sender
+    /// The event sender for events comming from clients.
     pub client_tx: mpmc::Sender<Event>,
-    /// The node event sender
+    /// The event sender for events comming from nodes.
+    /// This also includes our own bootstrapping events `Event::BootstrapFailure`
+    /// and `Event::BootstrappedTo` as well as `Event::Finish`.
     pub node_tx: mpmc::Sender<Event>,
 }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -29,8 +29,8 @@ impl Peer {
 
     pub(crate) fn is_node(&self) -> bool {
         match *self {
-            Peer::Node { .. } => false,
-            Peer::Client { .. } => true,
+            Peer::Node { .. } => true,
+            Peer::Client { .. } => false,
         }
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -26,6 +26,13 @@ impl Peer {
             Self::Node(addr) | Self::Client(addr) => addr,
         }
     }
+
+    pub(crate) fn is_node(&self) -> bool {
+        match *self {
+            Peer::Node { .. } => false,
+            Peer::Client { .. } => true,
+        }
+    }
 }
 
 impl fmt::Display for Peer {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,7 +15,7 @@ use crate::dirs::{Dirs, OverRide};
 use crate::event::Event;
 use crate::utils::{Token, R};
 use crate::wire_msg::WireMsg;
-use crate::{communicate, Builder, Peer, QuicP2p};
+use crate::{communicate, Builder, EventSenders, Peer, QuicP2p};
 use crossbeam_channel as mpmc;
 use futures::future::Future;
 use rand::Rng;
@@ -173,12 +173,40 @@ fn tmp_rand_dir() -> PathBuf {
     path
 }
 
+pub(crate) struct EventReceivers {
+    pub node_rx: mpmc::Receiver<Event>,
+    pub client_rx: mpmc::Receiver<Event>,
+}
+
+impl EventReceivers {
+    pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
+        self.node_rx.recv()
+    }
+
+    pub fn try_recv(&self) -> Result<Event, mpmc::TryRecvError> {
+        self.node_rx.try_recv()
+    }
+
+    pub fn iter(&self) -> mpmc::Iter<Event> {
+        self.node_rx.iter()
+    }
+}
+
+pub(crate) fn new_unbounded_channels() -> (EventSenders, EventReceivers) {
+    let (client_tx, client_rx) = mpmc::unbounded();
+    let (node_tx, node_rx) = mpmc::unbounded();
+    (
+        EventSenders { node_tx, client_tx },
+        EventReceivers { node_rx, client_rx },
+    )
+}
+
 /// Creates a new `QuicP2p` instance for testing.
 pub(crate) fn new_random_qp2p(
     is_addr_unspecified: bool,
     contacts: HashSet<SocketAddr>,
-) -> (QuicP2p, mpmc::Receiver<Event>) {
-    let (tx, rx) = mpmc::unbounded();
+) -> (QuicP2p, EventReceivers) {
+    let (tx, rx) = new_unbounded_channels();
     let qp2p = {
         let mut cfg = Config::with_default_cert();
         cfg.hard_coded_contacts = contacts;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -180,15 +180,53 @@ pub(crate) struct EventReceivers {
 
 impl EventReceivers {
     pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
-        self.node_rx.recv()
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.client_rx);
+        let node_idx = sel.recv(&self.node_rx);
+        let selected_operation = sel.ready();
+
+        if selected_operation == client_idx {
+            self.client_rx.recv()
+        } else if selected_operation == node_idx {
+            self.node_rx.recv()
+        } else {
+            panic!("invalid operation");
+        }
     }
 
     pub fn try_recv(&self) -> Result<Event, mpmc::TryRecvError> {
-        self.node_rx.try_recv()
+        self.node_rx
+            .try_recv()
+            .or_else(|_| self.client_rx.try_recv())
     }
 
-    pub fn iter(&self) -> mpmc::Iter<Event> {
-        self.node_rx.iter()
+    pub fn iter(&self) -> IterEvent {
+        IterEvent { event_rx: &self }
+    }
+}
+
+pub struct IterEvent<'a> {
+    event_rx: &'a EventReceivers,
+}
+
+impl<'a> Iterator for IterEvent<'a> {
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.event_rx.client_rx);
+        let node_idx = sel.recv(&self.event_rx.node_rx);
+        let selected_operation = sel.ready();
+
+        let event = if selected_operation == client_idx {
+            self.event_rx.client_rx.recv()
+        } else if selected_operation == node_idx {
+            self.event_rx.node_rx.recv()
+        } else {
+            return None;
+        };
+
+        event.ok()
     }
 }
 

--- a/tests/quic_p2p.rs
+++ b/tests/quic_p2p.rs
@@ -22,8 +22,32 @@ struct EventReceivers {
 }
 
 impl EventReceivers {
-    pub fn iter(&self) -> mpmc::Iter<Event> {
-        self.node_rx.iter()
+    pub fn iter(&self) -> IterEvent {
+        IterEvent { event_rx: &self }
+    }
+}
+pub struct IterEvent<'a> {
+    event_rx: &'a EventReceivers,
+}
+
+impl<'a> Iterator for IterEvent<'a> {
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.event_rx.client_rx);
+        let node_idx = sel.recv(&self.event_rx.node_rx);
+        let selected_operation = sel.ready();
+
+        let event = if selected_operation == client_idx {
+            self.event_rx.client_rx.recv()
+        } else if selected_operation == node_idx {
+            self.event_rx.node_rx.recv()
+        } else {
+            return None;
+        };
+
+        event.ok()
     }
 }
 


### PR DESCRIPTION
Address the quic-p2p work for https://github.com/maidsafe/routing/issues/2039

The aim is to allow Vault to pass in a channel for its client events.
`EventReceivers` was made explicitly not part of the API as the 2 channels will be held by different objects Vault and Routing.