### PR TITLE
Force the use of basic tokio scheduler

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -79,8 +79,11 @@ impl EventLoop {
                     }
                 };
 
-                let mut runtime =
-                    tokio::runtime::Runtime::new().expect("Cannot start Tokio runtime, aborting");
+                let mut runtime = tokio::runtime::Builder::new()
+                    .enable_all()
+                    .basic_scheduler()
+                    .build()
+                    .expect("Cannot start Tokio runtime, aborting");
                 runtime.block_on(event_loop_future);
 
                 debug!("Exiting QuicP2p Event Loop");


### PR DESCRIPTION
If quic-p2p was included as a dependency in a repo with tokio dep listing a rt-threaded feature, it defaulted to use the threaded scheduler, resulting in a failure of finding the quic-p2p context (which is a thread local variable). This commit provides a fix for this problem by forcing the use of the basic, single-threaded tokio scheduler.