### PR TITLE
Implement UPnP support and improve echo service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-quinn = { version = "~0.6.0", features = ["tls-rustls"], default-features = false }
+quinn = { version = "~0.6.1", features = ["tls-rustls"], default-features = false }
 futures = "~0.3.1"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
 unwrap = "~1.2.1"
 bincode = "~1.1.2"
-bytes = { version = "~0.4.12", features = ["serde"] }
+bytes = { version = "~0.5.4", features = ["serde"] }
 crossbeam-channel = "~0.4.2"
 igd = { version = "~0.10.2", features = ["aio"], optional = true }
 serde = { version = "~1.0.91", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"
 unwrap = "~1.2.1"
 bincode = "~1.1.2"
 bytes = { version = "~0.4.12", features = ["serde"] }
-crossbeam-channel = "~0.3.8"
+crossbeam-channel = "~0.4.2"
+igd = { version = "~0.10.2", features = ["aio"], optional = true }
 serde = { version = "~1.0.91", features = ["derive"] }
 serde_json = "~1.0.39"
 structopt = "~0.2.15"
@@ -34,8 +35,13 @@ clap = "~2.32.0"
 crc = "~1.8.1"
 env_logger = "~0.6.1"
 rustyline = "~4.1.0"
+tracing = "0.1"
+tracing-subscriber = "~0.2.4"
 unwrap = "~1.2.1"
 rand = "~0.6.5"
+
+[features]
+upnp = ["igd"]
 
 # Mobile and embedded platforms should not include these dependencies to override config file paths
 [target.'cfg(any(all(unix, not(any(target_os = "android", target_os = "androideabi", target_os = "ios"))), windows))'.dependencies]

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -13,7 +13,7 @@ mod common;
 
 use bytes::Bytes;
 use common::{new_unbounded_channels, EventReceivers};
-use quic_p2p::{Builder, Config, Event, Peer, QuicP2p};
+use quic_p2p::{Config, Event, Peer, QuicP2p};
 use rand::{distributions::Standard, Rng};
 use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
@@ -79,7 +79,12 @@ fn main() {
     let CliArgs { quic_p2p_opts } = CliArgs::from_args();
     let (ev_tx, ev_rx) = new_unbounded_channels();
 
-    let mut qp2p = unwrap!(Builder::new(ev_tx).with_config(quic_p2p_opts).build());
+    let mut qp2p = unwrap!(QuicP2p::with_config(
+        ev_tx,
+        Some(quic_p2p_opts),
+        Default::default(),
+        false
+    ));
 
     print_logo();
     println!("Type 'help' to get started.");

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -156,7 +156,7 @@ fn on_cmd_send<'a>(
         .and_then(|idx| idx.parse().or(Err("Invalid index argument")))
         .and_then(|idx| peer_list.get(idx).ok_or("Index out of bounds"))
         .map(|peer| {
-            let msg = Bytes::from(args.collect::<Vec<_>>().join(" ").as_bytes());
+            let msg = Bytes::from(args.collect::<Vec<_>>().join(" "));
             // TODO: handle tokens properly. Currently just hardcoding to 0 in example
             qp2p.send(peer.clone(), msg, 0);
         })

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-bytes = { version = "~0.4.12", features = ["serde"] }
+bytes = { version = "~0.5.4", features = ["serde"] }
 crossbeam-channel = "~0.4.2"
 fxhash = "~0.2.1"
 rand = "~0.7.2"

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bytes = { version = "~0.4.12", features = ["serde"] }
-crossbeam-channel = "~0.3.8"
+crossbeam-channel = "~0.4.2"
 fxhash = "~0.2.1"
 rand = "~0.7.2"
 serde = { version = "~1.0.91", features = ["derive"] }

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -8,7 +8,7 @@
 
 #![allow(clippy::mutable_key_type)]
 
-use super::{Builder, Config, Event, EventSenders, Network, OurType, Peer, QuicP2p};
+use super::{Config, Event, EventSenders, Network, OurType, Peer, QuicP2p};
 use bytes::Bytes;
 use crossbeam_channel::{self as mpmc, Receiver, TryRecvError};
 use fxhash::FxHashSet;
@@ -369,7 +369,7 @@ fn our_connection_info_of_node() {
         port: Some(addr.port()),
         ..Config::node()
     };
-    let mut node = unwrap!(Builder::new(tx).with_config(config).build());
+    let mut node = QuicP2p::with_config(tx, Some(config), Default::default(), false).unwrap();
 
     let node_addr = unwrap!(node.our_connection_info());
     assert_eq!(node_addr, addr);
@@ -380,7 +380,8 @@ fn our_connection_info_of_client() {
     let _network = Network::new();
 
     let (tx, _) = new_unbounded_channels();
-    let mut client = unwrap!(Builder::new(tx).with_config(Config::client()).build());
+    let mut client =
+        QuicP2p::with_config(tx, Some(Config::client()), Default::default(), false).unwrap();
 
     assert!(client.our_connection_info().is_err())
 }
@@ -441,7 +442,7 @@ impl Agent {
 
     fn with_config(config: Config) -> Self {
         let (tx, rx) = new_unbounded_channels();
-        let inner = unwrap!(Builder::new(tx).with_config(config).build());
+        let inner = QuicP2p::with_config(tx, Some(config), Default::default(), false).unwrap();
 
         Self { inner, rx }
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -7,34 +7,65 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::connect;
-use crate::connection::BootstrapGroupMaker;
-use crate::context::ctx;
+use crate::{
+    connect, connection::BootstrapGroupMaker, context::ctx, EventSenders, QuicP2pError, WireMsg,
+};
+use log::trace;
+use std::net::SocketAddr;
 
 pub fn start() {
-    let (bootstrap_nodes, event_tx): (Vec<_>, _) = ctx(|c| {
-        (
-            c.bootstrap_cache
-                .peers()
-                .iter()
-                .rev()
-                .chain(c.bootstrap_cache.hard_coded_contacts().iter())
-                .cloned()
-                .collect(),
-            c.event_tx.clone(),
-        )
-    });
+    let bootstrap_nodes = bootstrap_nodes();
+    let event_tx = ctx(|c| c.event_tx.clone());
 
     let maker = BootstrapGroupMaker::new(event_tx);
+    trace!("Bootstrapping to {:?}", bootstrap_nodes);
+
     for bootstrap_node in bootstrap_nodes {
         let _ = connect::connect_to(bootstrap_node, None, Some(&maker));
     }
 }
 
+/// Send a request to an echo service. By default uses the list of hardcoded contacts and the bootstrap cache.
+/// Returns `true` if we have been bootstrapped to someone already (in this case just an echo request will be sent).
+pub(crate) fn echo_request(notify: EventSenders) -> bool {
+    let bootstrap_nodes = bootstrap_nodes();
+
+    let mut maker = BootstrapGroupMaker::new(notify);
+    let send_after_connect = Some((WireMsg::EndpointEchoReq, 0));
+    trace!("Sending echo requests to nodes {:?}", bootstrap_nodes);
+
+    for bootstrap_node in bootstrap_nodes {
+        let res = connect::connect_to(bootstrap_node, send_after_connect.clone(), Some(&maker));
+        if let Err(QuicP2pError::DuplicateConnectionToPeer { peer_addr }) = res {
+            // We are already bootstrapped
+            maker.set_already_bootstrapped(peer_addr);
+            return true;
+        }
+    }
+
+    false
+}
+
+// Return a list of all hardcoded contacts along with the bootstrap cache.
+fn bootstrap_nodes() -> Vec<SocketAddr> {
+    ctx(|c| {
+        c.bootstrap_cache
+            .peers()
+            .iter()
+            .rev()
+            .chain(c.bootstrap_cache.hard_coded_contacts().iter())
+            .cloned()
+            .collect()
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{new_random_qp2p, new_unbounded_channels, EventReceivers};
-    use crate::{Builder, Config, Event, OurType, QuicP2p};
+    use crate::{
+        test_utils::new_random_qp2p,
+        utils::{new_unbounded_channels, EventReceivers},
+        Config, Event, OurType, QuicP2p,
+    };
     use std::collections::{HashSet, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::thread;
@@ -133,16 +164,18 @@ mod tests {
 
         // Waiting for all nodes to start
         let (ev_tx, ev_rx) = new_unbounded_channels();
-        let mut bootstrapping_node = unwrap!(Builder::new(ev_tx)
-            .with_config(Config {
+        let mut bootstrapping_node = unwrap!(QuicP2p::with_config(
+            ev_tx,
+            Some(Config {
                 port: Some(0),
                 ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 hard_coded_contacts,
                 our_type: OurType::Client,
                 ..Default::default()
-            })
-            .with_bootstrap_nodes(bootstrap_cache.clone(), true,)
-            .build());
+            }),
+            bootstrap_cache.clone(),
+            true
+        ));
 
         bootstrapping_node.bootstrap();
 
@@ -177,17 +210,19 @@ mod tests {
         assert!(hcc.insert(bootstrap_ci));
 
         let (ev_tx, ev_rx) = new_unbounded_channels();
-        let mut bootstrap_client = unwrap!(Builder::new(ev_tx)
-            .with_config(Config {
+        let mut bootstrap_client = unwrap!(QuicP2p::with_config(
+            ev_tx,
+            Some(Config {
                 port: Some(0),
                 ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 hard_coded_contacts: hcc,
                 our_type: OurType::Node,
                 idle_timeout_msec: Some(30),
                 ..Default::default()
-            })
-            .with_bootstrap_nodes(Default::default(), true)
-            .build());
+            }),
+            Default::default(),
+            true
+        ));
 
         bootstrap_client.bootstrap();
 
@@ -254,16 +289,20 @@ mod tests {
             }
         }
 
-        let is_peer1_state_valid = unwrap!(peer1.connections(move |c| {
-            c[&peer2_conn_info].from_peer.is_established()
-                && c[&peer2_conn_info].to_peer.is_not_needed()
-        }));
+        let is_peer1_state_valid = peer1
+            .connections(move |c| {
+                c[&peer2_conn_info].from_peer.is_established()
+                    && c[&peer2_conn_info].to_peer.is_not_needed()
+            })
+            .unwrap();
         assert!(is_peer1_state_valid);
 
-        let is_peer2_state_valid = unwrap!(peer2.connections(move |c| {
-            c[&peer1_conn_info].to_peer.is_established()
-                && c[&peer1_conn_info].from_peer.is_not_needed()
-        }));
+        let is_peer2_state_valid = peer2
+            .connections(move |c| {
+                c[&peer1_conn_info].to_peer.is_established()
+                    && c[&peer1_conn_info].from_peer.is_not_needed()
+            })
+            .unwrap();
         assert!(is_peer2_state_valid);
     }
 
@@ -320,14 +359,17 @@ mod tests {
     ) -> (QuicP2p, EventReceivers) {
         let cached_peers: VecDeque<_> = cached_peers.drain(..).collect();
         let (ev_tx, ev_rx) = new_unbounded_channels();
-        let builder = Builder::new(ev_tx)
-            .with_config(Config {
+        let quic_p2p = unwrap!(QuicP2p::with_config(
+            ev_tx,
+            Some(Config {
                 port: Some(0),
                 ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 ..Default::default()
-            })
-            .with_bootstrap_nodes(cached_peers, true);
-        (unwrap!(builder.build()), ev_rx)
+            }),
+            cached_peers,
+            true
+        ));
+        (quic_p2p, ev_rx)
     }
 
     /// Constructs a `QuicP2p` node with some sane defaults for testing.
@@ -341,16 +383,19 @@ mod tests {
         our_type: OurType,
     ) -> (QuicP2p, EventReceivers) {
         let (ev_tx, ev_rx) = new_unbounded_channels();
-        let builder = Builder::new(ev_tx)
-            .with_config(Config {
+        let quic_p2p = unwrap!(QuicP2p::with_config(
+            ev_tx,
+            Some(Config {
                 port: Some(0),
                 ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                 hard_coded_contacts,
                 our_type,
                 ..Default::default()
-            })
+            }),
             // Make sure we start with an empty cache. Otherwise, we might get into unexpected state.
-            .with_bootstrap_nodes(Default::default(), true);
-        (unwrap!(builder.build()), ev_rx)
+            Default::default(),
+            true
+        ));
+        (quic_p2p, ev_rx)
     }
 }

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -460,6 +460,7 @@ fn handle_echo_req(peer: Peer, q_conn: &QConn) {
 }
 
 fn handle_echo_resp(our_ext_addr: SocketAddr, inform_tx: Option<mpsc::Sender<SocketAddr>>) {
+    debug!("Echo service response. our_ext_addr: {:?}", our_ext_addr);
     if let Some(tx) = inform_tx {
         if let Err(e) = tx.send(our_ext_addr) {
             info!("Error informing endpoint echo service response: {:?}", e);
@@ -470,9 +471,8 @@ fn handle_echo_resp(our_ext_addr: SocketAddr, inform_tx: Option<mpsc::Sender<Soc
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{
-        new_random_qp2p, new_unbounded_channels, rand_node_addr, test_dirs, write_to_bi_stream,
-    };
+    use crate::test_utils::{new_random_qp2p, rand_node_addr, test_dirs, write_to_bi_stream};
+    use crate::utils::new_unbounded_channels;
     use std::collections::HashSet;
     use unwrap::unwrap;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,8 +11,6 @@ use crate::dirs::Dirs;
 use crate::error::QuicP2pError;
 use crate::utils;
 use crate::R;
-use base64;
-use bincode;
 use bytes::Bytes;
 use log::{trace, warn};
 use serde::{Deserialize, Serialize};
@@ -65,6 +63,9 @@ pub struct Config {
     /// default cache directory is used.
     #[structopt(long)]
     pub bootstrap_cache_dir: Option<String>,
+    /// Duration of a UPnP port mapping.
+    #[structopt(long)]
+    pub upnp_lease_duration: Option<u32>,
     /// Specify if we are a client or a node
     #[structopt(short = "t", long, default_value = "node")]
     pub our_type: OurType,
@@ -173,12 +174,12 @@ impl fmt::Debug for SerialisableCertificate {
     }
 }
 
-/// Whether we are a client or a node
+/// Whether we are a client or a node.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Eq, PartialEq)]
 pub enum OurType {
-    /// We are a client
+    /// We are a client. Clients do not expect a reverse connection from a peer.
     Client,
-    /// We are a node
+    /// We are a node. Nodes require a reverse connection from a peer.
     Node,
 }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -41,7 +41,7 @@ pub struct Connection {
     /// end of this connection.
     pub we_contacted_peer: bool,
     peer_addr: SocketAddr,
-    event_tx: EventSenders,
+    pub(crate) event_tx: EventSenders,
 }
 
 impl Connection {

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum QuicP2pError {
     #[error(display = "Could not use IGD for automatic port forwarding")]
     IgdAddPort(#[source] igd::AddAnyPortError),
     #[cfg(feature = "upnp")]
+    #[error(display = "Could not renew port mapping using IGD")]
+    IgdRenewPort(#[source] igd::AddPortError),
+    #[cfg(feature = "upnp")]
     #[error(display = "Could not find the gateway device for IGD")]
     IgdSearch(#[source] igd::SearchError),
     #[cfg(feature = "upnp")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,9 +9,8 @@
 
 use err_derive::Error;
 
-use std::io;
 use std::net::SocketAddr;
-use std::sync::mpsc;
+use std::{io, sync::mpsc};
 
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
@@ -34,7 +33,7 @@ pub enum QuicP2pError {
     DuplicateConnectionToPeer { peer_addr: SocketAddr },
     #[error(display = "Could not find enpoint server")]
     NoEndpointEchoServerFound,
-    #[error(display = "Oneshot receiver ")]
+    #[error(display = "Oneshot receiver")]
     OneShotRx(#[source] tokio::sync::oneshot::error::RecvError),
     #[error(display = "TLS Error ")]
     TLS(#[source] rustls::TLSError),
@@ -48,16 +47,27 @@ pub enum QuicP2pError {
     OperationNotAllowed,
     #[error(display = "Connection cancelled")]
     ConnectionCancelled,
-    #[error(display = "Channel receive error ")]
+    #[error(display = "MPMC channel receive error")]
+    MultiChannelRecv(#[source] crossbeam_channel::RecvError),
+    #[error(display = "Channel receive error")]
     ChannelRecv(#[source] mpsc::RecvError),
     #[error(display = "Could not add certificate to PKI")]
     WebPki,
     #[error(display = "Invalid wire message.")]
     InvalidWireMsgFlag,
-    #[error(display = "Stream write error ")]
+    #[error(display = "Stream write error")]
     WriteError(#[source] quinn::WriteError),
-    #[error(display = "Read to end error ")]
+    #[error(display = "Read to end error")]
     ReadToEndError(#[source] quinn::ReadToEndError),
-    #[error(display = "Could not add certificate ")]
+    #[error(display = "Could not add certificate")]
     AddCertificateError(#[source] quinn::ParseError),
+    #[cfg(feature = "upnp")]
+    #[error(display = "Could not use IGD for automatic port forwarding")]
+    IgdAddPort(#[source] igd::AddAnyPortError),
+    #[cfg(feature = "upnp")]
+    #[error(display = "Could not find the gateway device for IGD")]
+    IgdSearch(#[source] igd::SearchError),
+    #[cfg(feature = "upnp")]
+    #[error(display = "IGD is not supported")]
+    IgdNotSupported,
 }

--- a/src/igd.rs
+++ b/src/igd.rs
@@ -1,0 +1,118 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::error::QuicP2pError;
+use crate::utils::R;
+use log::{debug, info, warn};
+use std::net::{IpAddr, SocketAddrV4};
+use std::time::Duration;
+use tokio::time::{self, Instant};
+
+/// Default duration of a UPnP lease, in seconds.
+pub const DEFAULT_UPNP_LEASE_DURATION_SEC: u32 = 120;
+/// Duration of wait for a UPnP result to come back.
+pub const UPNP_RESPONSE_TIMEOUT_MSEC: u64 = 1_000;
+
+/// Automatically forwards a port and setups a tokio task to renew it periodically.
+pub async fn forward_port(local_port: u16, lease_duration: u32) -> R<SocketAddrV4> {
+    let igd_res = add_port(local_port, lease_duration).await;
+
+    if let Ok(ref ext_sock_addr) = igd_res {
+        // Start a tokio task to renew the lease periodically.
+        let ext_port = ext_sock_addr.port();
+        let lease_interval = Duration::from_secs(lease_duration.into());
+
+        let _ = tokio::spawn(async move {
+            let mut timer =
+                time::interval_at(Instant::now() + lease_interval.into(), lease_interval);
+
+            loop {
+                let _ = timer.tick().await;
+                debug!("Renewing IGD lease for port {}", local_port);
+
+                let renew_res = renew_port(local_port, ext_port, lease_duration).await;
+                match renew_res {
+                    Ok(()) => {}
+                    Err(e) => {
+                        warn!("Failed to renew IGD lease: {} - {:?}", e, e);
+                    }
+                }
+            }
+        });
+    }
+
+    igd_res
+}
+
+/// Attempts to map an external port to a local address.
+///
+/// `local_port` is the local listener's port that all requests will be redirected to.
+/// An external port is chosen randomly and returned as a result.
+///
+/// `lease_duration` is the life time of a port mapping (in seconds). If it is 0, the
+/// mapping will continue to exist as long as possible.
+pub(crate) async fn add_port(local_port: u16, lease_duration: u32) -> R<SocketAddrV4> {
+    let gateway = igd::aio::search_gateway(Default::default()).await?;
+
+    debug!("Found IGD gateway: {:?}", gateway);
+
+    // Find our local IP address by connecting to the gateway and querying local socket address.
+    let gateway_conn = tokio::net::TcpStream::connect(gateway.addr).await?;
+    let local_sa = gateway_conn.local_addr()?;
+
+    if let IpAddr::V4(ip) = local_sa.ip() {
+        let local_sa = SocketAddrV4::new(ip, local_port);
+
+        let ext_addr = gateway
+            .get_any_address(
+                igd::PortMappingProtocol::UDP,
+                local_sa,
+                lease_duration,
+                "MaidSafe.net",
+            )
+            .await?;
+
+        debug!("Our external address is {:?}", ext_addr);
+
+        Ok(ext_addr)
+    } else {
+        info!("IPv6 for IGD is not supported");
+        Err(QuicP2pError::IgdNotSupported)
+    }
+}
+
+/// Renews the lease for a specified external port.
+pub(crate) async fn renew_port(local_port: u16, ext_port: u16, lease_duration: u32) -> R<()> {
+    let gateway = igd::aio::search_gateway(Default::default()).await?;
+
+    // Find our local IP address by connecting to the gateway and querying local socket address.
+    let gateway_conn = tokio::net::TcpStream::connect(gateway.addr).await?;
+    let local_sa = gateway_conn.local_addr()?;
+
+    if let IpAddr::V4(ip) = local_sa.ip() {
+        let local_sa = SocketAddrV4::new(ip, local_port);
+
+        let _res = gateway
+            .add_port(
+                igd::PortMappingProtocol::UDP,
+                ext_port,
+                local_sa,
+                lease_duration,
+                "MaidSafe.net",
+            )
+            .await;
+
+        debug!("Successfully renewed the port mapping");
+
+        Ok(())
+    } else {
+        info!("IPv6 for IGD is not supported");
+        Err(QuicP2pError::IgdNotSupported)
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,19 +12,16 @@ use crate::connection::{Connection, FromPeer, QConn, ToPeer};
 use crate::context::ctx;
 use crate::context::Context;
 use crate::dirs::{Dirs, OverRide};
-use crate::event::Event;
-use crate::utils::{Token, R};
+use crate::utils::{new_unbounded_channels, EventReceivers, Token, R};
 use crate::wire_msg::WireMsg;
-use crate::{communicate, Builder, EventSenders, Peer, QuicP2p};
-use crossbeam_channel as mpmc;
+use crate::{communicate, Peer, QuicP2p};
 use futures::future::Future;
 use rand::Rng;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::path::PathBuf;
-use std::sync::mpsc;
-use std::{env, ops::Deref, time::Duration};
+use std::{env, ops::Deref, sync::mpsc, time::Duration};
 use unwrap::unwrap;
 
 thread_local! {
@@ -172,77 +169,13 @@ fn tmp_rand_dir() -> PathBuf {
     path
 }
 
-pub(crate) struct EventReceivers {
-    pub node_rx: mpmc::Receiver<Event>,
-    pub client_rx: mpmc::Receiver<Event>,
-}
-
-impl EventReceivers {
-    pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
-        let mut sel = mpmc::Select::new();
-        let client_idx = sel.recv(&self.client_rx);
-        let node_idx = sel.recv(&self.node_rx);
-        let selected_operation = sel.ready();
-
-        if selected_operation == client_idx {
-            self.client_rx.recv()
-        } else if selected_operation == node_idx {
-            self.node_rx.recv()
-        } else {
-            panic!("invalid operation");
-        }
-    }
-
-    pub fn try_recv(&self) -> Result<Event, mpmc::TryRecvError> {
-        self.node_rx
-            .try_recv()
-            .or_else(|_| self.client_rx.try_recv())
-    }
-
-    pub fn iter(&self) -> IterEvent {
-        IterEvent { event_rx: &self }
-    }
-}
-
-pub struct IterEvent<'a> {
-    event_rx: &'a EventReceivers,
-}
-
-impl<'a> Iterator for IterEvent<'a> {
-    type Item = Event;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut sel = mpmc::Select::new();
-        let client_idx = sel.recv(&self.event_rx.client_rx);
-        let node_idx = sel.recv(&self.event_rx.node_rx);
-        let selected_operation = sel.ready();
-
-        let event = if selected_operation == client_idx {
-            self.event_rx.client_rx.recv()
-        } else if selected_operation == node_idx {
-            self.event_rx.node_rx.recv()
-        } else {
-            return None;
-        };
-
-        event.ok()
-    }
-}
-
-pub(crate) fn new_unbounded_channels() -> (EventSenders, EventReceivers) {
-    let (client_tx, client_rx) = mpmc::unbounded();
-    let (node_tx, node_rx) = mpmc::unbounded();
-    (
-        EventSenders { node_tx, client_tx },
-        EventReceivers { node_rx, client_rx },
-    )
-}
-
 /// Creates a new `QuicP2p` instance for testing.
 pub(crate) fn new_random_qp2p(
     is_addr_unspecified: bool,
     contacts: HashSet<SocketAddr>,
 ) -> (QuicP2p, EventReceivers) {
+    let _ = env_logger::try_init();
+
     let (tx, rx) = new_unbounded_channels();
     let qp2p = {
         let mut cfg = Config::with_default_cert();
@@ -251,7 +184,12 @@ pub(crate) fn new_random_qp2p(
         if !is_addr_unspecified {
             cfg.ip = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
         }
-        unwrap!(Builder::new(tx).with_config(cfg).build())
+        unwrap!(QuicP2p::with_config(
+            tx,
+            Some(cfg),
+            Default::default(),
+            false
+        ))
     };
 
     (qp2p, rx)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,8 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-#![allow(unused)]
-
 use crate::{ctx_mut, dirs::Dirs, error::QuicP2pError, event::Event, peer::Peer, EventSenders};
 use crossbeam_channel as mpmc;
 use log::debug;
@@ -38,6 +36,7 @@ pub(crate) struct EventReceivers {
 }
 
 impl EventReceivers {
+    #![allow(unused)]
     pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
         let mut sel = mpmc::Select::new();
         let client_idx = sel.recv(&self.client_rx);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,10 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::{ctx_mut, dirs::Dirs, error::QuicP2pError, event::Event, peer::Peer};
+#![allow(unused)]
+
+use crate::{ctx_mut, dirs::Dirs, error::QuicP2pError, event::Event, peer::Peer, EventSenders};
+use crossbeam_channel as mpmc;
 use log::debug;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -15,6 +18,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::net::SocketAddr;
 use std::path::Path;
+use std::time::Duration;
 
 /// Result used by `QuicP2p`.
 pub type R<T> = Result<T, QuicP2pError>;
@@ -26,6 +30,89 @@ pub type ConnectTerminator = tokio::sync::mpsc::Sender<()>;
 /// Obtain a `ConnectTerminator` paired with a corresponding receiver.
 pub fn connect_terminator() -> (ConnectTerminator, tokio::sync::mpsc::Receiver<()>) {
     tokio::sync::mpsc::channel(1)
+}
+
+pub(crate) struct EventReceivers {
+    pub node_rx: mpmc::Receiver<Event>,
+    pub client_rx: mpmc::Receiver<Event>,
+}
+
+impl EventReceivers {
+    pub fn recv(&self) -> Result<Event, mpmc::RecvError> {
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.client_rx);
+        let node_idx = sel.recv(&self.node_rx);
+        let selected_operation = sel.ready();
+
+        if selected_operation == client_idx {
+            self.client_rx.recv()
+        } else if selected_operation == node_idx {
+            self.node_rx.recv()
+        } else {
+            panic!("invalid operation");
+        }
+    }
+
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<Event, QuicP2pError> {
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.client_rx);
+        let node_idx = sel.recv(&self.node_rx);
+        let selected_operation = sel.ready_timeout(timeout).map_err(|_| mpmc::RecvError)?;
+
+        if selected_operation == client_idx {
+            Ok(self.client_rx.recv()?)
+        } else if selected_operation == node_idx {
+            Ok(self.node_rx.recv()?)
+        } else {
+            panic!("invalid operation");
+        }
+    }
+
+    #[allow(unused)]
+    pub fn try_recv(&self) -> Result<Event, mpmc::TryRecvError> {
+        self.node_rx
+            .try_recv()
+            .or_else(|_| self.client_rx.try_recv())
+    }
+
+    #[allow(unused)]
+    pub fn iter(&self) -> IterEvent {
+        IterEvent { event_rx: &self }
+    }
+}
+
+pub struct IterEvent<'a> {
+    event_rx: &'a EventReceivers,
+}
+
+impl<'a> Iterator for IterEvent<'a> {
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut sel = mpmc::Select::new();
+        let client_idx = sel.recv(&self.event_rx.client_rx);
+        let node_idx = sel.recv(&self.event_rx.node_rx);
+        let selected_operation = sel.ready();
+
+        let event = if selected_operation == client_idx {
+            self.event_rx.client_rx.recv()
+        } else if selected_operation == node_idx {
+            self.event_rx.node_rx.recv()
+        } else {
+            return None;
+        };
+
+        event.ok()
+    }
+}
+
+pub(crate) fn new_unbounded_channels() -> (EventSenders, EventReceivers) {
+    let (client_tx, client_rx) = mpmc::unbounded();
+    let (node_tx, node_rx) = mpmc::unbounded();
+    (
+        EventSenders { node_tx, client_tx },
+        EventReceivers { node_rx, client_rx },
+    )
 }
 
 /// Get the project directory

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -14,7 +14,7 @@ use std::{fmt, net::SocketAddr};
 use unwrap::unwrap;
 
 /// Final type serialised and sent on the wire by QuicP2p
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WireMsg {
     Handshake(Handshake),
     EndpointEchoReq,
@@ -70,7 +70,7 @@ impl fmt::Display for WireMsg {
 /// passive connection from a peer will allow only incoming uni-directional streams from it.
 ///
 /// Depending on the handshake we will categorise the peer and give this information to the user.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum Handshake {
     /// The connecting peer is a node.
     Node,

--- a/tests/quic_p2p.rs
+++ b/tests/quic_p2p.rs
@@ -1,5 +1,5 @@
 use crossbeam_channel as mpmc;
-use quic_p2p::{Builder, Config, Event, EventSenders, OurType, Peer, QuicP2p};
+use quic_p2p::{Config, Event, EventSenders, OurType, Peer, QuicP2p};
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -70,17 +70,20 @@ fn test_peer_with_hcc(
     our_type: OurType,
 ) -> (QuicP2p, EventReceivers) {
     let (ev_tx, ev_rx) = new_unbounded_channels();
-    let builder = Builder::new(ev_tx)
-        .with_config(Config {
+    let qp2p = unwrap!(QuicP2p::with_config(
+        ev_tx,
+        Some(Config {
             port: Some(0),
             ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             hard_coded_contacts,
             our_type,
             ..Default::default()
-        })
+        }),
         // Make sure we start with an empty cache. Otherwise, we might get into unexpected state.
-        .with_bootstrap_nodes(Default::default(), true);
-    (unwrap!(builder.build()), ev_rx)
+        Default::default(),
+        true,
+    ));
+    (qp2p, ev_rx)
 }
 
 #[test]


### PR DESCRIPTION
- Use IGD for automatic port forwarding.
- Improve the echo service implementation: ping multiple contacts asynchronously to find own public IP address.
- Change the API: do not use the Builder pattern for QuicP2P initialization.