### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ edition = "2018"
 quinn = { version = "~0.6.1", features = ["tls-rustls"], default-features = false }
 futures = "~0.3.1"
 tokio = { version = "~0.2.5", features = ["rt-core", "sync", "time", "io-driver"] }
-unwrap = "~1.2.1"
-bincode = "~1.1.2"
+unwrap = "1.2.1"
+bincode = "1.2.1"
 bytes = { version = "~0.5.4", features = ["serde"] }
 crossbeam-channel = "~0.4.2"
 igd = { version = "~0.10.2", features = ["aio"], optional = true }
-serde = { version = "~1.0.91", features = ["derive"] }
-serde_json = "~1.0.39"
+serde = { version = "1.0.111", features = ["derive"] }
+serde_json = "1.0.53"
 structopt = "~0.2.15"
 rcgen = "~0.7.0"
 rustls = { version = "~0.17.0", features = ["dangerous_configuration"] }
@@ -31,14 +31,13 @@ derive_more = "^0.99.2"
 webpki = "~0.21.2"
 
 [dev-dependencies]
-clap = "~2.32.0"
-crc = "~1.8.1"
+clap = "2.32.0"
+crc = "1.8.1"
 env_logger = "~0.6.1"
-rustyline = "~4.1.0"
+rustyline = "4.1.0"
 tracing = "0.1"
 tracing-subscriber = "~0.2.4"
-unwrap = "~1.2.1"
-rand = "~0.6.5"
+rand = "~0.7.3"
 
 [features]
 upnp = ["igd"]

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -241,7 +241,7 @@ mod tests {
 
         let (mut peer2, ev_rx) = {
             let mut hcc = HashSet::new();
-            assert!(hcc.insert(peer1_conn_info.clone()));
+            assert!(hcc.insert(peer1_conn_info));
             test_peer_with_hcc(hcc, OurType::Node)
         };
 
@@ -275,7 +275,7 @@ mod tests {
 
         let (mut peer2, ev_rx) = {
             let mut hcc = HashSet::new();
-            assert!(hcc.insert(peer1_conn_info.clone()));
+            assert!(hcc.insert(peer1_conn_info));
             test_peer_with_hcc(hcc, OurType::Client)
         };
 

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -151,13 +151,13 @@ mod tests {
             let peer1 = rand_node_addr();
             let peer2 = rand_node_addr();
             let mut hard_coded: HashSet<_> = Default::default();
-            assert!(hard_coded.insert(peer1.clone()));
+            assert!(hard_coded.insert(peer1));
 
             let dirs = test_dirs();
-            let mut cache = unwrap!(BootstrapCache::new(hard_coded, Some(&dirs)));
+            let mut cache = BootstrapCache::new(hard_coded, Some(&dirs)).unwrap();
 
             cache.add_peer(peer1);
-            cache.add_peer(peer2.clone());
+            cache.add_peer(peer2);
 
             let peers: Vec<_> = cache.peers.iter().cloned().collect();
             assert_eq!(peers, vec![peer2]);
@@ -186,15 +186,15 @@ mod tests {
         #[test]
         fn it_moves_given_node_to_the_top_of_the_list() {
             let dirs = test_dirs();
-            let mut cache = unwrap!(BootstrapCache::new(Default::default(), Some(&dirs)));
+            let mut cache = BootstrapCache::new(Default::default(), Some(&dirs)).unwrap();
             let peer1 = rand_node_addr();
             let peer2 = rand_node_addr();
             let peer3 = rand_node_addr();
-            cache.add_peer(peer1.clone());
-            cache.add_peer(peer2.clone());
-            cache.add_peer(peer3.clone());
+            cache.add_peer(peer1);
+            cache.add_peer(peer2);
+            cache.add_peer(peer3);
 
-            cache.move_to_cache_top(peer2.clone());
+            cache.move_to_cache_top(peer2);
 
             let peers: Vec<_> = cache.peers.iter().cloned().collect();
             assert_eq!(peers, vec![peer1, peer3, peer2]);

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -480,18 +480,18 @@ mod tests {
     #[test]
     fn disallow_bidirectional_streams() {
         let (mut qp2p0, rx0) = new_random_qp2p(false, Default::default());
-        let qp2p0_info = unwrap!(qp2p0.our_connection_info());
+        let qp2p0_info = qp2p0.our_connection_info().unwrap();
 
         let (mut qp2p1, rx1) = {
             let mut hcc: HashSet<_> = Default::default();
-            assert!(hcc.insert(qp2p0_info.clone()));
+            assert!(hcc.insert(qp2p0_info));
             new_random_qp2p(true, hcc)
         };
         let qp2p1_info = unwrap!(qp2p1.our_connection_info());
 
         // Drain the message queues
-        while let Ok(_) = rx1.try_recv() {}
-        while let Ok(_) = rx0.try_recv() {}
+        while rx1.try_recv().is_ok() {}
+        while rx0.try_recv().is_ok() {}
 
         // Create a bi-directional stream and write data
         qp2p1.el.post(move || {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -78,7 +78,7 @@ impl<'a> EndpointWrap<'a> {
         impl Future<Output = Result<quinn::NewConnection, quinn::ConnectionError>>,
         quinn::ConnectError,
     > {
-        test_ctx_mut(|ctx| ctx.attempted_connections.push(addr.clone()));
+        test_ctx_mut(|ctx| ctx.attempted_connections.push(*addr));
 
         let connecting_res = self.0.connect_with(config, addr, server_name)?;
         let delay_ms = test_ctx(|ctx| ctx.connect_delay);


### PR DESCRIPTION
Use semver version specification (`1.2.3` instead of `~1.2.3`) to avoid conflicts on minor version change. Also updates some of the dependencies to the latest ones. 