### PR TITLE
chore(ci): add cargo-udeps check for duplicate dependencies to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
+  cargo-udeps:
+    name: Unused dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      # Install and run cargo udeps to find unused cargo dependencies
+      - name: cargo-udeps duplicate dependency check
+        run: |
+          cargo install cargo-udeps --locked
+          cargo +nightly udeps --all-targets
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -60,6 +60,7 @@ fn bootstrap_nodes() -> Vec<SocketAddr> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::{
         test_utils::new_random_qp2p,

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -123,6 +123,7 @@ impl BootstrapCache {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::test_utils::{make_node_addr, rand_node_addr, test_dirs};

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -469,6 +469,7 @@ fn handle_echo_resp(our_ext_addr: SocketAddr, inform_tx: Option<mpsc::Sender<Soc
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::test_utils::{new_random_qp2p, rand_node_addr, test_dirs, write_to_bi_stream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ impl QuicP2p {
             };
 
             let client_cfg =
-                peer_config::new_client_cfg(idle_timeout_msec, keep_alive_interval_msec).unwrap();
+                peer_config::new_client_cfg(idle_timeout_msec, keep_alive_interval_msec);
 
             let ctx = Context::new(
                 tx,
@@ -571,6 +571,7 @@ impl QuicP2p {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::utils::new_unbounded_channels;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
     while_true,
     clippy::unicode_not_nfc,
     clippy::wrong_pub_self_convention,
-    clippy::option_unwrap_used
+    clippy::unwrap_used
 )]
 #![warn(
     trivial_casts,

--- a/src/peer_config.rs
+++ b/src/peer_config.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_KEEP_ALIVE_INTERVAL_MSEC: u32 = 10_000; // 10secs
 pub fn new_client_cfg(
     idle_timeout_msec: u64,
     keep_alive_interval_msec: u32,
-) -> R<quinn::ClientConfig> {
+) -> quinn::ClientConfig {
     let mut cfg = quinn::ClientConfigBuilder::default().build();
     let crypto_cfg =
         Arc::get_mut(&mut cfg.crypto).expect("the crypto config should not be shared yet");
@@ -38,8 +38,8 @@ pub fn new_client_cfg(
     cfg.transport = Arc::new(new_transport_cfg(
         idle_timeout_msec,
         keep_alive_interval_msec,
-    )?);
-    Ok(cfg)
+    ));
+    cfg
 }
 
 pub fn new_our_cfg(
@@ -53,7 +53,7 @@ pub fn new_our_cfg(
         our_cfg.transport = Arc::new(new_transport_cfg(
             idle_timeout_msec,
             keep_alive_interval_msec,
-        )?);
+        ));
 
         quinn::ServerConfigBuilder::new(our_cfg)
     };
@@ -67,14 +67,15 @@ pub fn new_our_cfg(
 fn new_transport_cfg(
     idle_timeout_msec: u64,
     keep_alive_interval_msec: u32,
-) -> R<quinn::TransportConfig> {
+) -> quinn::TransportConfig {
     let mut transport_config = quinn::TransportConfig::default();
     let _ = transport_config
         .max_idle_timeout(Some(Duration::from_millis(idle_timeout_msec)))
-        .map_err(|e| QuicP2pError::Configuration { e: e.to_string() })?;
+        .map_err(|e| QuicP2pError::Configuration { e: e.to_string() })
+        .unwrap_or(&mut Default::default());
     let _ = transport_config
         .keep_alive_interval(Some(Duration::from_millis(keep_alive_interval_msec.into())));
-    Ok(transport_config)
+    transport_config
 }
 
 /// Dummy certificate verifier that treats any certificate as valid.


### PR DESCRIPTION
Note that the clippy errors in CI are unrelated to this PR. I had a go at resolving anyway, but the initial suggested changes led to another load of more complex errors so decided to leave it.