### PR TITLE
chore(name): update repo/crate name to new naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# quic-p2p - Change Log
+# quic_p2p - Change Log
 
 ## [0.7.0]
 - Standardize cargo dependency versioning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "quic-p2p"
+name = "quic_p2p"
 description = "Peer-to-peer networking library using QUIC"
-documentation = "https://docs.rs/quic-p2p"
+documentation = "https://docs.rs/quic_p2p"
 homepage = "https://maidsafe.net"
 license = "MIT OR BSD-3-Clause"
 readme = "README.md"
-repository = "https://github.com/maidsafe/quic-p2p"
+repository = "https://github.com/maidsafe/quic_p2p"
 version = "0.7.0"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# quic-p2p
+# quic_p2p
 
-|Crate|Documentation|Linux/macOS/Windows|
-|:---:|:-----------:|:-----------------:|
-|[![](http://meritbadge.herokuapp.com/quic-p2p)](https://crates.io/crates/quic-p2p)|[![Documentation](https://docs.rs/quic-p2p/badge.svg)](https://docs.rs/quic-p2p)|[![Build Status](https://travis-ci.com/maidsafe/quic-p2p.svg?branch=master)](https://travis-ci.com/maidsafe/quic-p2p)|
+|Crate|Documentation|
+|:---:|:-----------:|
+|[![](http://meritbadge.herokuapp.com/quic_p2p)](https://crates.io/crates/quic_p2p)|[![Documentation](https://docs.rs/quic_p2p/badge.svg)](https://docs.rs/quic_p2p)|
 
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:-------------------------------------:|:---------------------------------------:|:------------------------------------------:|
@@ -31,15 +31,15 @@ QUIC provides connection security via the use of TLS 1.3. This library will allo
 1. Allow use of a private certificate authority.
 1. Allow no identity validation of peers, but do encrypt connections. (currently implemented)
 
-This should satisfy the requirements of many P2P networks, whether they trust any clearnet certificate authority (which may be a centralised attack source) or whether they pass the identity management up to a different layer to validate identities and simply use quic-p2p as a secured network in terms of encrypted connections.
+This should satisfy the requirements of many P2P networks, whether they trust any clearnet certificate authority (which may be a centralised attack source) or whether they pass the identity management up to a different layer to validate identities and simply use quic_p2p as a secured network in terms of encrypted connections.
 
 ### Bootstrap Cache
 
-quic-p2p will save any endpoints and certificates of nodes that are connectible without any setup such as is required by NAT hole punching. The most recently connected 200 nodes are stored and these are then used to re-join the network after any restart.
+quic_p2p will save any endpoints and certificates of nodes that are connectible without any setup such as is required by NAT hole punching. The most recently connected 200 nodes are stored and these are then used to re-join the network after any restart.
 
 ### Connectivity types
 
-quic-p2p uses 2 connection types when in P2P mode. This allows the connections to be defined as:
+quic_p2p uses 2 connection types when in P2P mode. This allows the connections to be defined as:
 
 1. A bi-directional connection.
 

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "mock-quic-p2p"
-description = "Mock version of quic-p2p which doesn't use real network. For testing purposes only."
+name = "mock_quic_p2p"
+description = "Mock version of quic_p2p which doesn't use real network. For testing purposes only."
 homepage = "https://maidsafe.net"
 license = "MIT OR BSD-3-Clause"
-repository = "https://github.com/maidsafe/quic-p2p"
+repository = "https://github.com/maidsafe/quic_p2p"
 version = "0.1.0"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Error;
 
 impl std::fmt::Display for Error {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(formatter, "mock quic-p2p error")
+        write!(formatter, "mock quic_p2p error")
     }
 }
 
@@ -73,7 +73,7 @@ impl QuicP2p {
     /// connect to all peers which are specified in the config (`hard_coded_contacts`) or were
     /// previously cached. If one bootstrap connection succeeds, all other connections will be dropped.
     ///
-    /// In case of success `Event::BootstrapedTo` will be fired. On error quic-p2p will fire `Event::BootstrapFailure`.
+    /// In case of success `Event::BootstrapedTo` will be fired. On error quic_p2p will fire `Event::BootstrapFailure`.
     pub fn bootstrap(&mut self) {
         self.inner.borrow_mut().bootstrap()
     }

--- a/mock/src/node.rs
+++ b/mock/src/node.rs
@@ -179,7 +179,7 @@ impl Node {
                 }
             }
             Packet::ConnectFailure => {
-                // Note: the real quic-p2p does not emit anything on unsuccessful connection
+                // Note: the real quic_p2p does not emit anything on unsuccessful connection
                 // attempts, only when a previously successfully established connection gets
                 // dropped, but it will in the future.
                 self.clear_pending_messages(src);

--- a/mock/src/tests.rs
+++ b/mock/src/tests.rs
@@ -309,7 +309,7 @@ fn send_to_nonexisting_node() {
 
     // Note: the real quick-p2p will only emit `UnsentUserMessage` when a connection to the peer
     // was previously successfully established. That is not the case here, so we expect nothing.
-    // TODO: this is going to get changed in the real quic-p2p, remove comment then.
+    // TODO: this is going to get changed in the real quic_p2p, remove comment then.
     a.expect_unsent_message(&b_addr, &msg, 0);
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -93,7 +93,7 @@ impl QuicP2p {
         use_bootstrap_cache: bool,
     ) -> Result<Self> {
         let cfg = unwrap_config_or_default(cfg)?;
-        debug!("Config passed in to quic-p2p: {:?}", cfg);
+        debug!("Config passed in to quic_p2p: {:?}", cfg);
 
         let (port, allow_random_port) = cfg
             .port
@@ -288,7 +288,7 @@ fn bind(
 // Unwrap the conffig if provided by the user, otherwise construct the default one
 #[cfg(not(feature = "upnp"))]
 fn unwrap_config_or_default(cfg: Option<Config>) -> Result<Config> {
-    cfg.map_or(Config::read_or_construct_default(None), |cfg| Ok(cfg))
+    cfg.map_or(Config::read_or_construct_default(None), Ok)
 }
 
 #[cfg(feature = "upnp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! quic-p2p enables communication within a peer to peer network over the QUIC protocol.
+//! quic_p2p enables communication within a peer to peer network over the QUIC protocol.
 
 // For explanation of lint checks, run `rustc -W help`
 #![forbid(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,7 @@ use std::path::Path;
 ))]
 #[inline]
 pub fn project_dir() -> Result<Dirs> {
-    let dirs = directories::ProjectDirs::from("net", "MaidSafe", "quic-p2p")
+    let dirs = directories::ProjectDirs::from("net", "MaidSafe", "quic_p2p")
         .ok_or_else(|| Error::Io(::std::io::ErrorKind::NotFound.into()))?;
     Ok(Dirs::Desktop(dirs))
 }


### PR DESCRIPTION
also contains a small clippy fix