### PR TITLE
Connection pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,31 +12,16 @@ keywords = [ "quic" ]
 edition = "2018"
 
 [dependencies]
-futures = "~0.3.5"
-unwrap = "1.2.1"
-bincode = "1.2.1"
-crossbeam-channel = "~0.4.2"
-serde_json = "1.0.59"
-flexi_logger = "~0.16.1"
-structopt = "~0.3.15"
-rcgen = "~0.8.4"
-log = "~0.4.8"
 base64 = "~0.12.2"
+bincode = "1.2.1"
 err-derive = "~0.2.4"
+flexi_logger = "~0.16.1"
+futures = "~0.3.5"
+log = "~0.4.8"
+rcgen = "~0.8.4"
+serde_json = "1.0.59"
+structopt = "~0.3.15"
 webpki = "~0.21.3"
-
-  [dependencies.serde]
-  version = "1.0.117"
-  features = [ "derive" ]
-
-  [dependencies.quinn]
-  version = "~0.6.1"
-  features = [ "tls-rustls" ]
-  default-features = false
-
-  [dependencies.tokio]
-  version = "~0.2.21"
-  features = [ "rt-core", "sync", "time", "macros", "io-std", "io-util" ]
 
   [dependencies.bytes]
   version = "~0.5.5"
@@ -46,9 +31,22 @@ webpki = "~0.21.3"
   version = "~0.11.1"
   features = [ "aio" ]
 
+  [dependencies.quinn]
+  version = "~0.6.1"
+  features = [ "tls-rustls" ]
+  default-features = false
+
   [dependencies.rustls]
   version = "~0.17.0"
   features = [ "dangerous_configuration" ]
+
+  [dependencies.serde]
+  version = "1.0.117"
+  features = [ "derive" ]
+
+  [dependencies.tokio]
+  version = "~0.2.21"
+  features = [ "rt-core", "sync", "time", "macros", "io-std", "io-util" ]
 
 [dev-dependencies]
 rand = "~0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ webpki = "~0.21.3"
   features = [ "rt-core", "sync", "time", "macros", "io-std", "io-util" ]
 
 [dev-dependencies]
+assert_matches = "1.3"
 rand = "~0.7.3"
 
 [target."cfg(any(all(unix, not(any(target_os = \"android\", target_os = \"androideabi\", target_os = \"ios\"))), windows))".dependencies]

--- a/examples/echo_service.rs
+++ b/examples/echo_service.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Error> {
     println!("Process running at: {}", &socket_addr);
     if genesis {
         println!("Waiting for connections");
-        let mut incoming = endpoint.listen()?;
+        let mut incoming = endpoint.listen();
         let mut messages = incoming
             .next()
             .await
@@ -63,8 +63,8 @@ async fn main() -> Result<(), Error> {
     } else {
         println!("Echo service complete");
         let node_addr = bootstrap_nodes[0];
-        let connection = endpoint.connect_to(&node_addr).await?;
-        let (mut send, mut recv) = connection.open_bi_stream().await?;
+        let (connection, _) = endpoint.connect_to(&node_addr).await?;
+        let (mut send, mut recv) = connection.open_bi().await?;
         loop {
             println!("Enter message:");
             let mut input = String::new();

--- a/src/api.rs
+++ b/src/api.rs
@@ -391,7 +391,7 @@ async fn new_connection_to(
         bootstrap_nodes,
         qp2p_config,
     )?;
-    let connection = endpoint.connect_to(node_addr).await?;
+    let (connection, _) = endpoint.connect_to(node_addr).await?;
 
     Ok((endpoint, connection))
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,7 @@ use super::{
     utils::init_logging,
 };
 use bytes::Bytes;
-use futures::future::select_ok;
+use futures::future;
 use log::{debug, error, info, trace};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::path::PathBuf;
@@ -228,48 +228,25 @@ impl QuicP2p {
     /// }
     /// ```
     pub async fn bootstrap(&self) -> Result<(Endpoint, Connection)> {
-        // TODO: refactor bootstrap_cache so we can simply get the list of nodes
-        let bootstrap_nodes: Vec<SocketAddr> = self
-            .bootstrap_cache
-            .peers()
-            .iter()
-            .rev()
-            .chain(self.bootstrap_cache.hard_coded_contacts().iter())
-            .cloned()
-            .collect();
+        let endpoint = self.new_endpoint()?;
 
-        trace!("Bootstrapping with nodes {:?}", bootstrap_nodes);
+        trace!("Bootstrapping with nodes {:?}", endpoint.bootstrap_nodes());
+
         // Attempt to connect to all nodes and return the first one to succeed
-        let mut tasks = Vec::default();
-        for node_addr in bootstrap_nodes.iter().cloned() {
-            let qp2p_config = self.qp2p_config.clone();
-            let nodes = bootstrap_nodes.clone();
-            let endpoint_cfg = self.endpoint_cfg.clone();
-            let client_cfg = self.client_cfg.clone();
-            let local_addr = self.local_addr;
-            let allow_random_port = self.allow_random_port;
-            let task_handle = tokio::spawn(async move {
-                new_connection_to(
-                    &node_addr,
-                    endpoint_cfg,
-                    client_cfg,
-                    local_addr,
-                    allow_random_port,
-                    nodes,
-                    qp2p_config,
-                )
-                .await
-            });
-            tasks.push(task_handle);
-        }
+        let tasks = endpoint
+            .bootstrap_nodes()
+            .iter()
+            .map(|addr| Box::pin(endpoint.connect_to(addr)));
 
-        let (result, _) = select_ok(tasks).await.map_err(|err| {
-            error!("Failed to botstrap to the network: {}", err);
-            Error::BootstrapFailure
-        })?;
+        let conn = match future::select_ok(tasks).await {
+            Ok(((conn, _incoming_messages), _)) => conn,
+            Err(err) => {
+                log::error!("Failed to botstrap to the network: {}", err);
+                return Err(Error::BootstrapFailure);
+            }
+        };
 
-        let (endpoint, connection) = result?;
-        Ok((endpoint, connection))
+        Ok((endpoint, conn))
     }
 
     /// Connect to the given peer and return the `Endpoint` created along with the `Connection`
@@ -295,25 +272,10 @@ impl QuicP2p {
     /// }
     /// ```
     pub async fn connect_to(&self, node_addr: &SocketAddr) -> Result<(Endpoint, Connection)> {
-        let bootstrap_nodes: Vec<SocketAddr> = self
-            .bootstrap_cache
-            .peers()
-            .iter()
-            .rev()
-            .chain(self.bootstrap_cache.hard_coded_contacts().iter())
-            .cloned()
-            .collect();
+        let endpoint = self.new_endpoint()?;
+        let (conn, _) = endpoint.connect_to(node_addr).await?;
 
-        new_connection_to(
-            node_addr,
-            self.endpoint_cfg.clone(),
-            self.client_cfg.clone(),
-            self.local_addr,
-            self.allow_random_port,
-            bootstrap_nodes,
-            self.qp2p_config.clone(),
-        )
-        .await
+        Ok((endpoint, conn))
     }
 
     /// Create a new `Endpoint`  which can be used to connect to peers and send
@@ -367,34 +329,6 @@ impl QuicP2p {
 }
 
 // Private helpers
-
-// Creates a new Connection
-async fn new_connection_to(
-    node_addr: &SocketAddr,
-    endpoint_cfg: quinn::ServerConfig,
-    client_cfg: quinn::ClientConfig,
-    local_addr: SocketAddr,
-    allow_random_port: bool,
-    bootstrap_nodes: Vec<SocketAddr>,
-    qp2p_config: Config,
-) -> Result<(Endpoint, Connection)> {
-    trace!("Attempting to connect to peer: {}", node_addr);
-
-    let (quinn_endpoint, quinn_incoming) = bind(endpoint_cfg, local_addr, allow_random_port)?;
-
-    trace!("Bound connection to local address: {}", local_addr);
-
-    let endpoint = Endpoint::new(
-        quinn_endpoint,
-        quinn_incoming,
-        client_cfg,
-        bootstrap_nodes,
-        qp2p_config,
-    )?;
-    let (connection, _) = endpoint.connect_to(node_addr).await?;
-
-    Ok((endpoint, connection))
-}
 
 // Bind a new socket with a local address
 fn bind(

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -147,7 +147,6 @@ impl BootstrapCache {
 mod tests {
     use super::*;
     use crate::test_utils::{make_node_addr, rand_node_addr, test_dirs};
-    use unwrap::unwrap;
 
     mod add_peer {
         use super::*;
@@ -155,7 +154,7 @@ mod tests {
         #[test]
         fn when_10_peers_are_added_they_are_synced_to_disk() {
             let dirs = test_dirs();
-            let mut cache = unwrap!(BootstrapCache::new(Default::default(), Some(&dirs), false));
+            let mut cache = BootstrapCache::new(Default::default(), Some(&dirs), false).unwrap();
 
             for _ in 0..10 {
                 cache.add_peer(rand_node_addr());
@@ -163,7 +162,7 @@ mod tests {
 
             assert_eq!(cache.peers.len(), 10);
 
-            let cache = unwrap!(BootstrapCache::new(Default::default(), Some(&dirs), false));
+            let cache = BootstrapCache::new(Default::default(), Some(&dirs), false).unwrap();
             assert_eq!(cache.peers.len(), 10);
         }
 
@@ -189,7 +188,7 @@ mod tests {
             let dirs = test_dirs();
             let port_base = 5000;
 
-            let mut cache = unwrap!(BootstrapCache::new(Default::default(), Some(&dirs), false));
+            let mut cache = BootstrapCache::new(Default::default(), Some(&dirs), false).unwrap();
 
             for i in 0..MAX_CACHE_SIZE {
                 cache.add_peer(make_node_addr(port_base + i as u16));

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,6 @@ use std::{
     collections::HashSet, fmt, fs, io, net::IpAddr, net::SocketAddr, path::PathBuf, str::FromStr,
 };
 use structopt::StructOpt;
-use unwrap::unwrap;
 
 /// QuicP2p configurations
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq, StructOpt)]
@@ -135,12 +134,10 @@ impl SerialisableCertificate {
 
 impl Default for SerialisableCertificate {
     fn default() -> Self {
-        let cert = unwrap!(rcgen::generate_simple_self_signed(vec![
-            "MaidSAFE.net".to_string()
-        ]));
+        let cert = rcgen::generate_simple_self_signed(vec!["MaidSAFE.net".to_string()]).unwrap();
 
         Self {
-            cert_der: unwrap!(cert.serialize_der()).into(),
+            cert_der: cert.serialize_der().unwrap().into(),
             key_der: cert.serialize_private_key_der().into(),
         }
     }
@@ -160,7 +157,7 @@ impl FromStr for SerialisableCertificate {
 impl ToString for SerialisableCertificate {
     /// Convert `SerialisableCertificate` into a base64-encoded string.
     fn to_string(&self) -> String {
-        let cert = unwrap!(bincode::serialize(&(&self.cert_der, &self.key_der)));
+        let cert = bincode::serialize(&(&self.cert_der, &self.key_der)).unwrap();
         base64::encode(&cert)
     }
 }
@@ -195,12 +192,12 @@ mod tests {
     #[test]
     fn config_create_read_and_write() {
         let dir = test_dirs();
-        let config_path = unwrap!(config_path(Some(&dir)));
+        let config_path = config_path(Some(&dir)).unwrap();
 
         assert!(utils::read_from_disk::<Config>(&config_path).is_err());
 
-        let cfg = unwrap!(Config::read_or_construct_default(Some(&dir)));
-        let read_cfg = unwrap!(utils::read_from_disk(&config_path));
+        let cfg = Config::read_or_construct_default(Some(&dir)).unwrap();
+        let read_cfg = utils::read_from_disk(&config_path).unwrap();
 
         assert_eq!(cfg, read_cfg);
     }

--- a/src/connection_deduplicator.rs
+++ b/src/connection_deduplicator.rs
@@ -1,0 +1,86 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use super::connections::Connection;
+use err_derive::Error;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::SocketAddr,
+};
+use tokio::sync::{broadcast, Mutex};
+
+type Result<T = Connection, E = Error> = std::result::Result<T, E>;
+
+// Deduplicate multiple concurrent connect attempts to the same peer - they all will yield the
+// same `Connection` instead of opening a separate connection each.
+pub(crate) struct ConnectionDeduplicator {
+    map: Mutex<HashMap<SocketAddr, broadcast::Sender<Result>>>,
+}
+
+impl ConnectionDeduplicator {
+    pub fn new() -> Self {
+        Self {
+            map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    // Query if there already is a connect attempt to the given address.
+    // If this is the first connect attempt, it returns `None` and we should proceed with
+    // establishing the connection and then call `complete` with the result.
+    // For any subsequent connect attempt this returns `Some` with the result of that attempt.
+    pub async fn query(&self, addr: &SocketAddr) -> Option<Result> {
+        let mut rx = match self.map.lock().await.entry(*addr) {
+            Entry::Occupied(entry) => entry.get().subscribe(),
+            Entry::Vacant(entry) => {
+                let (tx, _) = broadcast::channel(1);
+                let _ = entry.insert(tx);
+                return None;
+            }
+        };
+
+        if let Ok(result) = rx.recv().await {
+            Some(result)
+        } else {
+            // NOTE: this branch cannot realistically happen, because we never drop the `Sender`
+            // without sending through it first and we also take it out of the map before doing so
+            // which means it's not possible to create more subscription on it after the send.
+            // This, however, is not statically provable so we still need to nominally handle this
+            // branch. We return `LocallyClosed` which seems like it would be the right error to
+            // return if this situation was actually possible (it isn't) as it would signal the
+            // caller to either abandon the connect or try to repeat it.
+            Some(Err(quinn::ConnectionError::LocallyClosed.into()))
+        }
+    }
+
+    // Signal completion of a connect attempt. This causes all the pending `query` calls for the
+    // same `addr` to return `result`.
+    pub async fn complete(&self, addr: &SocketAddr, result: Result) {
+        let tx = self.map.lock().await.remove(addr);
+        if let Some(tx) = tx {
+            let _ = tx.send(result);
+        }
+    }
+}
+
+#[derive(Clone, Error, Debug)]
+pub(crate) enum Error {
+    #[error(display = "Connect error")]
+    Connect(#[source] quinn::ConnectError),
+    #[error(display = "Connection error")]
+    Connection(#[source] quinn::ConnectionError),
+}
+
+impl From<Error> for crate::error::Error {
+    fn from(src: Error) -> Self {
+        match src {
+            Error::Connect(source) => Self::Connect(source),
+            Error::Connection(source) => Self::Connection(source),
+        }
+    }
+}

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -74,6 +74,10 @@ impl ConnectionRemover {
         let mut store = self.store.lock().unwrap_or_else(PoisonError::into_inner);
         let _ = store.map.remove(&self.key);
     }
+
+    pub fn remote_addr(&self) -> &SocketAddr {
+        &self.key.addr
+    }
 }
 
 #[derive(Default)]

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -1,0 +1,78 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use slotmap::{DefaultKey, DenseSlotMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+};
+
+#[derive(Clone)]
+pub(crate) struct ConnectionPool {
+    store: Arc<RwLock<Store>>,
+}
+
+impl ConnectionPool {
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(Store {
+                connections: DenseSlotMap::new(),
+                keys: HashMap::new(),
+            })),
+        }
+    }
+
+    pub fn insert(&self, conn: quinn::Connection) -> Handle {
+        let addr = conn.remote_address();
+
+        let mut store = self.store.write().expect("RwLock poisoned");
+        let key = store.connections.insert(conn);
+        let _ = store.keys.insert(addr, key);
+
+        Handle {
+            store: self.store.clone(),
+            key,
+        }
+    }
+
+    pub fn get(&self, addr: &SocketAddr) -> Option<quinn::Connection> {
+        let store = self.store.read().ok()?;
+        let key = store.keys.get(addr)?;
+        store.connections.get(*key).cloned()
+    }
+}
+
+pub(crate) struct Handle {
+    store: Arc<RwLock<Store>>,
+    key: DefaultKey,
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        let mut store = if let Ok(store) = self.store.write() {
+            store
+        } else {
+            return;
+        };
+
+        if let Some(conn) = store.connections.remove(self.key) {
+            if let Entry::Occupied(entry) = store.keys.entry(conn.remote_address()) {
+                if entry.get() == &self.key {
+                    let _ = entry.remove();
+                }
+            }
+        }
+    }
+}
+
+struct Store {
+    connections: DenseSlotMap<DefaultKey, quinn::Connection>,
+    keys: HashMap<SocketAddr, DefaultKey>,
+}

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -103,8 +103,7 @@ impl Connection {
     /// Gracefully close connection immediatelly
     pub fn close(&self) {
         self.quic_conn.close(0u32.into(), b"");
-        // TODO: uncomment
-        // self.remover.remove();
+        self.remover.remove();
     }
 
     fn handle_error<T, E>(&self, result: Result<T, E>) -> Result<T, E> {
@@ -178,7 +177,7 @@ impl IncomingMessages {
 
     /// Returns the address of the peer who initiated the connection
     pub fn remote_addr(&self) -> SocketAddr {
-        *self.pool_handle.remote_addr()
+        *self.remover.remote_addr()
     }
 
     /// Returns next message sent by the peer on current QUIC connection,

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -20,6 +20,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::select;
 
 /// Connection instance to a node which can be used to send messages to it
+#[derive(Clone)]
 pub struct Connection {
     quic_conn: quinn::Connection,
     remover: ConnectionRemover,

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -25,12 +25,6 @@ pub struct Connection {
     remover: ConnectionRemover,
 }
 
-impl Drop for Connection {
-    fn drop(&mut self) {
-        self.close();
-    }
-}
-
 impl Connection {
     pub(crate) fn new(quic_conn: quinn::Connection, remover: ConnectionRemover) -> Self {
         Self { quic_conn, remover }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -154,7 +154,8 @@ impl Endpoint {
         }
     }
 
-    /// Connects to another peer
+    /// Connects to another peer.
+    ///
     ///
     pub async fn connect_to(
         &self,
@@ -172,14 +173,12 @@ impl Endpoint {
 
         trace!("Successfully connected to peer: {}", node_addr);
 
-        let guard = self.connection_pool.insert(
-            new_conn.connection.remote_address(),
-            new_conn.connection.clone(),
-        );
+        let guard = self
+            .connection_pool
+            .insert(*node_addr, new_conn.connection.clone());
 
         let conn = Connection::new(new_conn.connection, guard.clone());
-        let incoming_msgs =
-            IncomingMessages::new(*node_addr, new_conn.uni_streams, new_conn.bi_streams, guard);
+        let incoming_msgs = IncomingMessages::new(new_conn.uni_streams, new_conn.bi_streams, guard);
 
         Ok((conn, Some(incoming_msgs)))
     }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -226,6 +226,11 @@ impl Endpoint {
         IncomingConnections::new(self.quic_incoming.clone(), self.connection_pool.clone())
     }
 
+    /// Close all the connections of this endpoint immediately and stop accepting new connections.
+    pub fn close(&self) {
+        self.quic_endpoint.close(0u32.into(), b"")
+    }
+
     // Private helper
     async fn query_ip_echo_service(&self) -> Result<SocketAddr> {
         // Bail out early if we don't have any contacts.

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -254,4 +254,8 @@ impl Endpoint {
         })?;
         result
     }
+
+    pub(crate) fn bootstrap_nodes(&self) -> &[SocketAddr] {
+        &self.bootstrap_nodes
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,8 +51,6 @@ pub enum Error {
     OperationNotAllowed,
     #[error(display = "Connection cancelled")]
     ConnectionCancelled,
-    #[error(display = "MPMC channel receive error")]
-    MultiChannelRecv(#[source] crossbeam_channel::RecvError),
     #[error(display = "Channel receive error")]
     ChannelRecv(#[source] mpsc::RecvError),
     #[error(display = "Could not add certificate to PKI")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use std::{io, sync::mpsc};
 
 /// Result used by `QuicP2p`.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, Error)]
 #[allow(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,7 @@
     unused_parens,
     while_true,
     clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention,
-    clippy::unwrap_used
+    clippy::wrong_pub_self_convention
 )]
 #![warn(
     trivial_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub use config::Config;
 pub use connections::{Connection, IncomingConnections, IncomingMessages, RecvStream, SendStream};
 pub use endpoint::Endpoint;
 pub use error::{Error, Result};
+pub use quinn::ConnectionError;
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 mod api;
 mod bootstrap_cache;
 mod config;
+mod connection_deduplicator;
 mod connection_pool;
 mod connections;
 mod endpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 mod api;
 mod bootstrap_cache;
 mod config;
+mod connection_pool;
 mod connections;
 mod endpoint;
 mod error;

--- a/src/tests/echo_service.rs
+++ b/src/tests/echo_service.rs
@@ -19,7 +19,7 @@ async fn echo_service() -> Result<()> {
 
     // Listen for messages / connections at peer 1
     let handle1 = tokio::spawn(async move {
-        let mut incoming = peer1.listen()?;
+        let mut incoming = peer1.listen();
         let mut inbound_messages = incoming
             .next()
             .await
@@ -32,8 +32,8 @@ async fn echo_service() -> Result<()> {
     let handle2 = tokio::spawn(async move {
         let peer2 = qp2p.new_endpoint()?;
         let socket_addr = peer2.socket_addr().await?;
-        let connection = peer2.connect_to(&peer1_addr).await?;
-        let (mut send_stream, mut recv_stream) = connection.open_bi_stream().await?;
+        let (connection, _) = peer2.connect_to(&peer1_addr).await?;
+        let (mut send_stream, mut recv_stream) = connection.open_bi().await?;
         let echo_service_req = WireMsg::EndpointEchoReq;
         echo_service_req
             .write_to_stream(&mut send_stream.quinn_send_stream)

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -15,7 +15,6 @@ use bytes::Bytes;
 use log::trace;
 use serde::{Deserialize, Serialize};
 use std::{fmt, net::SocketAddr};
-use unwrap::unwrap;
 
 const MSG_HEADER_LEN: usize = 9;
 const MSG_PROTOCOL_VERSION: u16 = 0x0001;
@@ -63,7 +62,7 @@ impl WireMsg {
         let (msg_bytes, msg_flag) = match self {
             WireMsg::UserMsg(ref m) => (m.clone(), USER_MSG_FLAG),
             _ => (
-                From::from(unwrap!(bincode::serialize(&self))),
+                From::from(bincode::serialize(&self).unwrap()),
                 ECHO_SRVC_MSG_FLAG,
             ),
         };


### PR DESCRIPTION
Connections are now stored in a pool and reused. See the doc comment for `Endpoint::connect_to` for more details about how this works. 

This is API breaking:

- `Endpoint::connect_to` return type changed from `Result<Connection>` to `Result<(Connection, Option<IncomingMessages>)>`.
- Similarly, `QuicP2p::bootstrap` return type changed from `Result<(Endpoint, Connection)>` to `Result<(Endpoint, Connection, IncomingMessages)>`
- `Connection` no longer automatically closes the underlying `quinn::Connection` on drop. It is only closed when the `quinn::Connection` and all its associated streams get dropped. 
- `Connection::send` renamed to `Connection::send_bi` and `Connection::open_bi_stream` renamed to `Connection::open_bi` - for consistency
- `Endpoint::listen` no longer returns `Result`