### PR TITLE
chore(cd): skip cache generation when building on macOS

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,6 +41,8 @@ jobs:
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2
+        # TODO: temporarily disable cache on macos due to weird issues with serde_derive crate. Needs further investigation.
+        if: matrix.os != 'macOS-latest'
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Seems there is an issue with serde_derive when using cache on
macOS. Skipping cache creation on that platform for now.