### PR TITLE
chore: use deny(warnings) instead of forbid(warnings)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     bad_style,
@@ -35,7 +34,8 @@
     unused_parens,
     while_true,
     clippy::unicode_not_nfc,
-    clippy::wrong_pub_self_convention
+    clippy::wrong_pub_self_convention,
+    warnings
 )]
 #![warn(
     trivial_casts,


### PR DESCRIPTION
`deny` can be overriden with `allow`, unlike `forbid`. This allows us to `allow` some warnings on a case-by-case basis which is especially useful in macros. Without this, some macros from other crates caused compilation errors on nightly, however it's possible it would eventually affect stable as well.