### PR TITLE
chore(ci): add PR size check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,6 +48,15 @@ jobs:
       - name: Clippy checks
         run: cargo clippy --workspace --all-targets --all-features
 
+  check_pr_size:
+    name: Check PR size doesn't break set limit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: maidsafe/pr_size_checker@v1.1
+      with:
+        max_lines_changed: 200
+  
   coverage:
     if: github.repository_owner == 'maidsafe'
     name: Code coverage check


### PR DESCRIPTION
Checks total lines changed is not greater than set number.

An example of what a fail will look like:
![image](https://user-images.githubusercontent.com/37112040/106596649-3c179e00-654d-11eb-896d-b847c7ea2eb3.png)

See this PR for an example where it passes.