### PR TITLE
Use existing port to validate EndpointVerificationReqs

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -175,6 +175,7 @@ impl Endpoint {
             message_tx,
             connection_tx,
             disconnection_tx,
+            endpoint.clone(),
         );
 
         Ok((
@@ -367,6 +368,7 @@ impl Endpoint {
             guard,
             self.message_tx.clone(),
             self.disconnection_tx.clone(),
+            self.clone(),
         );
 
         self.connection_deduplicator


### PR DESCRIPTION
When using the default Qp2p configuration to create a temporary endpoint to validate EndpointVerificationReqs, if there is an error we cannot recover from it. So we should either re-use the same configuration or re-use the endpoint itself.﻿
