### PR TITLE
Fix stalled connections with multiple boostrap contacts

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -183,7 +183,7 @@ impl QuicP2p {
         let tasks = endpoint
             .bootstrap_nodes()
             .iter()
-            .map(|addr| Box::pin(endpoint.new_connection(addr)));
+            .map(|addr| Box::pin(endpoint.create_new_connection(addr)));
 
         let successful_connection = future::select_ok(tasks)
             .await
@@ -194,7 +194,7 @@ impl QuicP2p {
             .0;
 
         let bootstrapped_peer = successful_connection.connection.remote_address();
-        endpoint.add_new_connection(successful_connection);
+        endpoint.add_new_connection_to_pool(successful_connection);
 
         Ok((
             endpoint,

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -371,7 +371,7 @@ impl Endpoint {
 
         trace!("Successfully connected to peer: {}", node_addr);
 
-        self.add_new_connection(new_conn);
+        self.add_new_connection_to_pool(new_conn);
 
         self.connection_deduplicator
             .complete(node_addr, Ok(()))
@@ -381,7 +381,7 @@ impl Endpoint {
     }
 
     /// Creates a fresh connection without looking at the connection pool and connection duplicator.
-    pub(crate) async fn new_connection(
+    pub(crate) async fn create_new_connection(
         &self,
         peer_addr: &SocketAddr,
     ) -> Result<quinn::NewConnection> {
@@ -394,7 +394,7 @@ impl Endpoint {
         Ok(new_connection)
     }
 
-    pub(crate) fn add_new_connection(&self, conn: quinn::NewConnection) {
+    pub(crate) fn add_new_connection_to_pool(&self, conn: quinn::NewConnection) {
         let guard = self
             .connection_pool
             .insert(conn.connection.remote_address(), conn.connection);


### PR DESCRIPTION
When multiple bootstrap contacts are used the first successful
connection is considered and the rest is disregarded. This results in
unfinished connection attempts that are left lingering in the connection
de-duplicator and connection pool. This fix introduces
Endpoint::new_connection that creates a fresh connection
disregarding the de-duplication of connections that is used by the
bootstrap function which then only saves the successful connection in the pool
