### PR TITLE
refactor(igd): use same port number for internal and external ports

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -263,9 +263,10 @@ impl Endpoint {
             .await
             {
                 Ok(res) => match res {
-                    Ok(public_sa) => {
-                        debug!("IGD success: {:?}", SocketAddr::V4(public_sa));
-                        addr = Some(SocketAddr::V4(public_sa));
+                    Ok(port) => {
+                        if let Some(socket) = &mut addr {
+                            socket.set_port(port);
+                        }
                     }
                     Err(e) => {
                         info!("IGD request failed: {} - {:?}", e, e);


### PR DESCRIPTION
this will allow nodes to use the address that it identifies during an
incoming connection for connectivity checks and return transmission
