### PR TITLE
fix(igd): Fix the condition for terminating the IGD renewal loop

### DIFF
--- a/src/igd.rs
+++ b/src/igd.rs
@@ -32,7 +32,7 @@ pub async fn forward_port(
 
             loop {
                 let _ = timer.tick().await;
-                if let Err(TryRecvError::Empty) = termination_rx.try_recv() {
+                if termination_rx.try_recv() != Err(TryRecvError::Empty) {
                     break;
                 }
                 debug!("Renewing IGD lease for port {}", local_addr);


### PR DESCRIPTION
- d0f01bd **fix(igd): Fix the condition for terminating the IGD renewal loop**

  The condition was the wrong way around. The desired behaviour is that
  closing an endpoint causes the renewal loop to stop. When an endpoint
  is closed, a message (`()`) is sent to the `termination_tx`, which is
  connected to the `termination_rx` in the renewal loop. Therefore we want
  to break the loop if we *have* received a message, indicating that the
  endpoint was closed.
  
  The condition would also terminate the loop on any other error from
  `try_recv` (e.g. if the endpoint was dropped), and this has been
  preserved.
