### PR TITLE
feat!: Client support for incoming messages and disconnections

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -194,13 +194,17 @@ impl<I: ConnId> Endpoint<I> {
     pub fn new_client(
         local_addr: impl Into<SocketAddr>,
         config: Config,
-    ) -> Result<Self, ClientEndpointError> {
+    ) -> Result<(Self, IncomingMessages, DisconnectionEvents), ClientEndpointError> {
         let config = InternalConfig::try_from_config(config)?;
 
-        let (endpoint, _, _) =
+        let (endpoint, _, channels) =
             Self::build_endpoint(local_addr.into(), config, quinn::Endpoint::builder())?;
 
-        Ok(endpoint)
+        Ok((
+            endpoint,
+            IncomingMessages(channels.message.1),
+            DisconnectionEvents(channels.disconnection.1),
+        ))
     }
 
     // A private helper for initialising an endpoint.


### PR DESCRIPTION
- 4e24e84 **feat!: Client support for incoming messages and disconnections**

  The original assumption was that clients would communicate with servers
  exclusively using bidirectional streams initiated by the client. This
  was thought to be the only way to ensure that clients did not have to be
  reachable or able to serve incoming connections.
  
  However, QUIC allows any side of a connection to initiate streams,
  meaning that a client-initiated connection could still receive incoming
  streams from the server. The API as it stood did not support this, since
  we would not give callers of `new_client` any way of receiving messages
  sent to clients in this way.
  
  Ultimately, the only technical limitation of clients is that they are
  unable to handle incoming *connections* (and thus do not need to be
  reachable or have server configuration), so the `new_client` function
  now returns `IncomingMessages` and `DisconnectionEvents` since these
  remain applicable.
  
  BREAKING CHANGE: The signature of `Endpoint::new_client` has changed to
  return a tuple of `(Endpoint, IncomingMessages, DisconnectionEvents)`
  rather than just the `Endpoint`.
