### PR TITLE
fix: Correctly mark `UpnpError` source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -459,4 +459,4 @@ pub struct UnsupportedStreamOperation(Box<dyn std::error::Error + Send + Sync>);
 #[cfg(not(feature = "no-igd"))]
 #[derive(Debug, Error)]
 #[error("Failed to establish UPnP port forwarding")]
-pub struct UpnpError(IgdError);
+pub struct UpnpError(#[source] IgdError);


### PR DESCRIPTION
- a312b48 **fix: Correctly mark `UpnpError` source**

  This annotation was simply missed out. Without it, the root cause for
  IGD errors are not visible.
