### PR TITLE
Better IGD logging

### DIFF
--- a/src/igd.rs
+++ b/src/igd.rs
@@ -29,8 +29,6 @@ pub(crate) enum IgdError {
     Search(#[from] igd::SearchError),
 }
 
-impl IgdError {}
-
 /// Automatically forwards a port and setups a tokio task to renew it periodically.
 pub(crate) async fn forward_port(
     ext_port: u16,

--- a/src/igd.rs
+++ b/src/igd.rs
@@ -84,7 +84,7 @@ pub(crate) async fn add_port(
 
     debug!("IGD gateway found: {:?}", gateway);
 
-    debug!("Our local address is: {:?}", local_addr);
+    debug!("Adding port mapping for {} -> {}", ext_port, local_addr);
 
     let local_addr = match local_addr {
         SocketAddr::V4(local_addr) => local_addr,

--- a/src/igd.rs
+++ b/src/igd.rs
@@ -23,9 +23,6 @@ pub(crate) enum IgdError {
     NotSupported,
 
     #[error(transparent)]
-    AddAnyPort(#[from] igd::AddAnyPortError),
-
-    #[error(transparent)]
     AddPort(#[from] igd::AddPortError),
 
     #[error(transparent)]


### PR DESCRIPTION
- 12a8e94 **chore: Log more information before adding port mapping**

  This lets us see the port that we're trying to map.

- 6916edc **chore: Remove unused `IgdError` variant**

  This was probably copied over from before. There's not breakage here
  since the enum is crate-private.

- efbd233 **chore: Remove empty `impl` block**

