### PR TITLE
Drop `no-igd` feature in favour of existing `igd` feature

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,8 +168,10 @@ jobs:
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
       # Run tests.
-      - name: Run tests
+      - name: Run tests (default features)
         run: cargo test --release --workspace -- --skip echo_service # test would timeout on CI
+      - name: Run tests (no default features)
+        run: cargo test --no-default-features --release --workspace -- --skip echo_service # test would timeout on CI
 
   # Test publish using --dry-run.
   test-publish:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,3 @@ tracing-subscriber = "0.2.19"
 
 [features]
 default = [ "igd" ]
-no-igd = [ ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,7 @@ pub struct CertificateGenerationError(
 pub struct Config {
     /// Specify if port forwarding via UPnP should be done or not. This can be set to false if the network
     /// is run locally on the network loopback or on a local area network.
+    #[cfg(feature = "igd")]
     #[structopt(long)]
     pub forward_port: bool,
 
@@ -141,6 +142,7 @@ fn parse_millis(millis: &str) -> Result<Duration, std::num::ParseIntError> {
 pub(crate) struct InternalConfig {
     pub(crate) client: quinn::ClientConfig,
     pub(crate) server: quinn::ServerConfig,
+    #[cfg(feature = "igd")]
     pub(crate) forward_port: bool,
     pub(crate) external_port: Option<u16>,
     pub(crate) external_ip: Option<IpAddr>,
@@ -168,6 +170,7 @@ impl InternalConfig {
         Ok(Self {
             client,
             server,
+            #[cfg(feature = "igd")]
             forward_port: config.forward_port,
             external_port: config.external_port,
             external_ip: config.external_ip,

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -9,7 +9,7 @@
 
 use crate::connection_pool::ConnId;
 
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 use super::igd::{forward_port, IgdError};
 use super::wire_msg::WireMsg;
 use super::{
@@ -38,7 +38,7 @@ use tracing::{debug, error, info, trace, warn};
 const CERT_SERVER_NAME: &str = "MaidSAFE.net";
 
 // Number of seconds before timing out the IGD request to forward a port.
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 const PORT_FORWARD_TIMEOUT: Duration = Duration::from_secs(30);
 
 // Number of seconds before timing out the echo service query.
@@ -144,7 +144,7 @@ impl<I: ConnId> Endpoint<I> {
         let contact = endpoint.connect_to_any(contacts).await;
         let public_addr = endpoint.resolve_public_addr(contact).await?;
 
-        #[cfg(not(feature = "no-igd"))]
+        #[cfg(feature = "igd")]
         if endpoint.config.forward_port {
             timeout(
                 PORT_FORWARD_TIMEOUT,

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@
 
 use super::wire_msg::WireMsg;
 use crate::config::ConfigError;
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 use crate::igd::IgdError;
 use bytes::Bytes;
 use std::{fmt, io, net::SocketAddr};
@@ -38,7 +38,7 @@ pub enum EndpointError {
     },
 
     /// Failed to establish UPnP port forwarding.
-    #[cfg(not(feature = "no-igd"))]
+    #[cfg(feature = "igd")]
     #[error(transparent)]
     Upnp(#[from] UpnpError),
 
@@ -69,7 +69,7 @@ impl From<quinn::EndpointError> for EndpointError {
     }
 }
 
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 impl From<IgdError> for EndpointError {
     fn from(error: IgdError) -> Self {
         Self::Upnp(UpnpError(error))
@@ -466,7 +466,7 @@ pub enum StreamError {
 pub struct UnsupportedStreamOperation(Box<dyn std::error::Error + Send + Sync>);
 
 /// Failed to establish UPnP port forwarding.
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 #[derive(Debug, Error)]
 #[error("Failed to establish UPnP port forwarding")]
 pub struct UpnpError(#[source] IgdError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ mod connection_pool;
 mod connections;
 mod endpoint;
 mod error;
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 mod igd;
 mod utils;
 mod wire_msg;
@@ -62,7 +62,7 @@ pub use config::{Config, ConfigError};
 pub use connection_pool::ConnId;
 pub use connections::{DisconnectionEvents, RecvStream, SendStream};
 pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
-#[cfg(not(feature = "no-igd"))]
+#[cfg(feature = "igd")]
 pub use error::UpnpError;
 pub use error::{
     ClientEndpointError, Close, ConnectionError, EndpointError, InternalConfigError, RecvError,


### PR DESCRIPTION
- b5ee260 **refactor!: Remove `no-igd` feature**

  Since `igd` is already an optional dependency, we already have an `igd`
  feature which is enabled by default. To disable IGD, we can simply use
  `default-features = false` or `--no-default-features`.
  
  BREAKING CHANGE: The `no-igd` feature has been removed.

- 1d9e38d **refactor!: Make `Config::port_forward` depend on `igd` feature**

  The `Config` struct will no longer have a `port_forward` field if the
  `igd` feature is not enabled. This removes a case where a user could set
  the config, but we would ignore it.
  
  BREAKING CHANGE: The `port_forward` field on `Config` is only present
  with the `igd` feature enabled (default).

- a3ec0b7 **ci: Run tests both with and without `igd` feature**

  This ensures we don't accidentally release changes that won't work with
  the `igd` feature disabled.
