### PR TITLE
fix: tweak timeouts and retries to reduce mem impact of open connecti…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,10 +16,10 @@ use std::{net::IpAddr, sync::Arc, time::Duration};
 ///
 /// This is based on average time in which routers would close the UDP mapping to the peer if they
 /// see no conversation between them.
-pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Default for [`Config::keep_alive_interval`] (20 seconds).
-pub const DEFAULT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(20);
+pub const DEFAULT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Default for [`Config::upnp_lease_duration`] (2 minutes).
 pub const DEFAULT_UPNP_LEASE_DURATION: Duration = Duration::from_secs(120);


### PR DESCRIPTION
- only retry w/ config supplies
- dont retry new connections
- tweak default timeouts

There's a positive impact on mem here it seems, w/ less connections in flights. Not wild, but there (mem seems to drop faster).

Leaving as draft for now as I want to keep testing some