### PR TITLE
Expose `Connection<I>`

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,12 +3,9 @@ on: [pull_request]
 
 jobs:
   lint:
-    if: github.repository_owner == 'maidsafe'
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372
+      - uses: wagoid/commitlint-github-action@59203cb6ee1ce85035e6fe7b3aa878cf80653739

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,16 +110,17 @@ jobs:
       !startsWith(github.event.pull_request.title, 'Automated version bump')
     name: Unused dependency check
     runs-on: ubuntu-latest
+    env:
+      CARGO_HTTP_MULTIPLEXING: 'false'
+      RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
-
       - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
+        uses: aig787/cargo-udeps-action@1cd634a329e14ccfbccfe7c96497d14dac24a743
         with:
           version: 'latest'
           args: '--all-targets'

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 /// gives 5-6 retries in ~30 s total retry time.
 pub const DEFAULT_MAX_RETRY_INTERVAL: Duration = Duration::from_secs(15);
 
-/// Default for [`RetryConfig::retry_interval_multiplier`] (x1.5).
+/// Default for [`RetryConfig::retry_delay_multiplier`] (x1.5).
 ///
 /// Together with the default max and initial,
 /// gives 5-6 retries in ~30 s total retry time.

--- a/src/connection_deduplicator.rs
+++ b/src/connection_deduplicator.rs
@@ -167,6 +167,6 @@ mod tests {
     }
 
     fn timeout<Fut: Future + Unpin>(fut: Fut) -> impl Future<Output = Result<Fut::Output>> + Unpin {
-        Box::pin(tokio::time::timeout(Duration::from_millis(100), fut).err_into())
+        Box::pin(tokio::time::timeout(Duration::from_millis(200), fut).err_into())
     }
 }

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -148,12 +148,11 @@ struct Store<I: ConnId> {
     id_gen: IdGen,
 }
 
-/// Unique key identifying a connection. Two connections will always have distict keys even if they
-/// have the same socket address.
+/// An application-defined identifier for a connection.
 pub trait ConnId:
     Clone + Copy + Eq + PartialEq + Ord + PartialOrd + Default + Send + Sync + 'static
 {
-    /// Generate
+    /// Generate an ID for the given `SocketAddr`.
     fn generate(socket_addr: &SocketAddr) -> Self;
 }
 

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -54,6 +54,11 @@ impl<I: ConnId> Connection<I> {
         Self { quic_conn, remover }
     }
 
+    /// Get the ID under which the connection is stored in the pool.
+    pub fn id(&self) -> I {
+        self.remover.id()
+    }
+
     /// Get the address of the connected peer.
     pub fn remote_address(&self) -> SocketAddr {
         self.quic_conn.remote_address()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -360,20 +360,20 @@ impl<I: ConnId> Endpoint<I> {
         }
     }
 
-    /// Get the connection ID of an existing pooled connection with the provided socket address.
-    pub async fn get_connection_id(&self, addr: &SocketAddr) -> Option<I> {
+    /// Get the existing `Connection` for a `SocketAddr`.
+    pub async fn get_connection_by_addr(&self, addr: &SocketAddr) -> Option<Connection<I>> {
         self.connection_pool
             .get_by_addr(addr)
             .await
-            .map(|(_, remover)| remover.id())
+            .map(|(connection, remover)| Connection::new(connection, remover))
     }
 
-    /// Get the `SocketAddr` of an existing pooled connection with the provided connection ID.
-    pub async fn get_socket_addr_by_id(&self, id: &I) -> Option<SocketAddr> {
+    /// Get the existing `Connection` for the given ID.
+    pub async fn get_connection_by_id(&self, id: &I) -> Option<Connection<I>> {
         self.connection_pool
             .get_by_id(id)
             .await
-            .map(|(_, remover)| *remover.remote_addr())
+            .map(|(connection, remover)| Connection::new(connection, remover))
     }
 
     /// Open a bi-directional stream with a given peer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,7 @@
     unused_features,
     unused_parens,
     while_true,
-    clippy::unicode_not_nfc,
-    warnings
+    clippy::unicode_not_nfc
 )]
 #![warn(
     trivial_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod wire_msg;
 
 pub use config::{Config, ConfigError, RetryConfig};
 pub use connection_pool::ConnId;
-pub use connections::{DisconnectionEvents, RecvStream, SendStream};
+pub use connections::{Connection, DisconnectionEvents, RecvStream, SendStream};
 pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
 #[cfg(feature = "igd")]
 pub use error::UpnpError;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,8 +8,8 @@
 // Software.
 
 use crate::{
-    Config, ConnId, DisconnectionEvents, Endpoint, IncomingConnections, IncomingMessages,
-    RetryConfig,
+    Config, ConnId, Connection, DisconnectionEvents, Endpoint, IncomingConnections,
+    IncomingMessages, RetryConfig,
 };
 use bytes::Bytes;
 use color_eyre::eyre::Result;
@@ -42,7 +42,7 @@ pub(crate) async fn new_endpoint() -> Result<(
     IncomingConnections,
     IncomingMessages,
     DisconnectionEvents,
-    Option<SocketAddr>,
+    Option<Connection<[u8; 32]>>,
 )> {
     Ok(Endpoint::new(
         local_addr(),


### PR DESCRIPTION
- 366e0dc **chore: don't deny warnings in source**

  It's considered an anti-pattern to deny warnings in the source itself.
  It's better to configure this in the environment, which we already do
  for CI with `-D warnings`.

- ce50e47 **feat!: return `Connection` from `Endpoint::connect_*`**

  This is a small step towards removing the `ConnectionPool`. The
  `ConnectionPool` is used for a number of things, one of which is
  enabling the `Endpoint` APIs that operate exclusively on `SocketAddr`s,
  rather than connection handles.
  
  This commit exposes the `Connection<I>` type, and updates the
  `Endpoint::new`, `Endpoint::connect_to`, and `Endpoint::connect_to_any`
  methods to return `Connection<I>` rather than `SocketAddr`. For now, the
  only public method on `Connection<I>` is `remote_address`, which callers
  can then use with the existing (unchanged) `SocketAddr`-based `Endpoint`
  APIs. Future commits will introduce additional `Connection` methods to
  replace these `SocketAddr`-based APIs.
  
  BREAKING CHANGE: `Endpoint::new`, `Endpoint::connect_to`, and
  `Endpoint::connect_to_any` now use `Connection<I>` instead of
  `SocketAddr` in their return type.

- 4f0cf52 **docs: expand and clarify `Endpoint` method documentation**

  This mostly cleans up existing information about connection pooling and
  priority. Connection pooling info has been added to each method, to make
  sure the behaviour is clear in each case.

- bc0b5c7 **docs: fix a broken intra-doc link**


- 7d0b710 **ci: upgrade `wagoid/commitlint-github-action`**

  The new version has tighter defaults, which should prevent us from
  committing dodgy commit types like `wip`. The `GITHUB_TOKEN` has also
  been removed, since the repository is public and the action is read
  only.

- 54d1040 **refactor!: replace `Endpoint` `addr`/`id` getters**

  Rather than `Endpoint` having getters for `addr`
  (`get_socket_addr_by_id`) and `id` (`get_connection_id`) there are now
  only getters for `Connection`, either by `addr`
  (`get_connection_by_addr`) or by `id` (`get_connection_by_id`).
  
  For now this mostly adds indirection for callers, who can call
  `Connection::id` or `Connection::remote_address` on the result to
  achieve the same outcome as before.
  
  BREAKING CHANGE: `Endpoint::get_connection_id` and
  `Endpoint::get_socket_addr_by_id` have been removed.
  `Endpoint::get_connection_by_addr` and `Endpoint::get_connection_by_id`
  can be used instead to get a `Connection`, from which the `id` or
  `remote_address` can be retrieved.

- b3bdf3c **ci: fix `cargo-udeps` action**

  `CARGO_HTTP_MULTIPLEXING` has been disabled, which seems to have
  resolved our network woes, and `-D warnings` is removed from `RUSTFLAGS`
  for that job, since new nightlies may introduce additional lints that we
  wouldn't otherwise block. The SHA of the action has been pinned also, to
  ensure there are no surprise updates.

- 7110a3f **test: bump timeouts in `ConnectionDeduplicator` tests**

  The timing-based tests for this module are flaky, but since
  `ConnectionDeduplicator` isn't long for this world we'll live with
  bumping the timeout for now.
