### PR TITLE
Move message sending API to `Connection`

### DIFF
--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -60,8 +60,7 @@ async fn main() -> Result<()> {
                 .expect("Invalid SocketAddr.  Use the form 127.0.0.1:1234");
             let msg = Bytes::from(MSG_MARCO);
             println!("Sending to {:?} --> {:?}\n", peer, msg);
-            node.connect_to(&peer).await?;
-            node.send_message(msg.clone(), &peer, 0).await?;
+            node.connect_to(&peer).await?.send(msg.clone()).await?;
         }
     }
 
@@ -74,7 +73,10 @@ async fn main() -> Result<()> {
         println!("Received from {:?} --> {:?}", socket_addr, bytes);
         if bytes == *MSG_MARCO {
             let reply = Bytes::from(MSG_POLO);
-            node.send_message(reply.clone(), &socket_addr, 0).await?;
+            node.connect_to(&socket_addr)
+                .await?
+                .send(reply.clone())
+                .await?;
             println!("Replied to {:?} --> {:?}", socket_addr, reply);
         }
         println!();

--- a/src/config.rs
+++ b/src/config.rs
@@ -219,7 +219,7 @@ pub(crate) struct InternalConfig {
     pub(crate) external_port: Option<u16>,
     pub(crate) external_ip: Option<IpAddr>,
     pub(crate) upnp_lease_duration: Duration,
-    pub(crate) retry_config: RetryConfig,
+    pub(crate) retry_config: Arc<RetryConfig>,
 }
 
 impl InternalConfig {
@@ -244,7 +244,7 @@ impl InternalConfig {
             external_port: config.external_port,
             external_ip: config.external_ip,
             upnp_lease_duration,
-            retry_config: config.retry_config,
+            retry_config: Arc::new(config.retry_config),
         })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,21 +140,6 @@ pub struct Config {
     pub retry_config: RetryConfig,
 }
 
-/// Config that has passed validation.
-///
-/// Generally this is a copy of [`Config`] without optional values where we would use defaults.
-#[derive(Clone, Debug)]
-pub(crate) struct InternalConfig {
-    pub(crate) client: quinn::ClientConfig,
-    pub(crate) server: quinn::ServerConfig,
-    #[cfg(feature = "igd")]
-    pub(crate) forward_port: bool,
-    pub(crate) external_port: Option<u16>,
-    pub(crate) external_ip: Option<IpAddr>,
-    pub(crate) upnp_lease_duration: Duration,
-    pub(crate) retry_config: RetryConfig,
-}
-
 /// Retry configurations for establishing connections and sending messages.
 /// Determines the retry behaviour of requests, by setting the back off strategy used.
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
@@ -220,6 +205,21 @@ impl Default for RetryConfig {
             retrying_max_elapsed_time: DEFAULT_RETRYING_MAX_ELAPSED_TIME,
         }
     }
+}
+
+/// Config that has passed validation.
+///
+/// Generally this is a copy of [`Config`] without optional values where we would use defaults.
+#[derive(Clone, Debug)]
+pub(crate) struct InternalConfig {
+    pub(crate) client: quinn::ClientConfig,
+    pub(crate) server: quinn::ServerConfig,
+    #[cfg(feature = "igd")]
+    pub(crate) forward_port: bool,
+    pub(crate) external_port: Option<u16>,
+    pub(crate) external_ip: Option<IpAddr>,
+    pub(crate) upnp_lease_duration: Duration,
+    pub(crate) retry_config: RetryConfig,
 }
 
 impl InternalConfig {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -456,13 +456,13 @@ impl<I: ConnId> Endpoint<I> {
         msg: Bytes,
         dest: &SocketAddr,
         priority: i32,
-        retries: Option<RetryConfig>,
+        retries: Option<&RetryConfig>,
     ) -> Result<(), Option<SendError>> {
         if let Some((conn, guard)) = self.connection_pool.get_by_addr(dest).await {
             trace!("Connection exists in the connection pool: {}", dest);
             let connection = Connection::new(conn, guard);
             retries
-                .unwrap_or(self.config.retry_config)
+                .unwrap_or(&self.config.retry_config)
                 .retry(|| async { Ok(connection.send_uni(msg.clone(), priority).await?) })
                 .await?;
             Ok(())
@@ -522,11 +522,11 @@ impl<I: ConnId> Endpoint<I> {
         msg: Bytes,
         dest: &SocketAddr,
         priority: i32,
-        retries: Option<RetryConfig>,
+        retries: Option<&RetryConfig>,
     ) -> Result<(), SendError> {
         let connection = self.get_or_connect_to(dest).await?;
         retries
-            .unwrap_or(self.config.retry_config)
+            .unwrap_or(&self.config.retry_config)
             .retry(|| async { Ok(connection.send_uni(msg.clone(), priority).await?) })
             .await?;
 


### PR DESCRIPTION
- 839810b **refactor: move retry logic into `RetryConfig`**

  This moves the `Endpoint::retry` function, which is responsible for
  performing an operation with retries based on a given `RetryConfig`, to
  an impl on the `RetryConfig` struct. This is a more logical place for it
  and allows us to use it from other types (spoiler alert: `Connection`).

- c3f6fd0 **refactor!: use `&RetryConfig` for retry overrides**

  This is primarily in preparation for changing `Endpoint::retry_config`
  to `Arc<RetryConfig>` so that it can be efficiently shared with
  `Connection`s. It also quite likely that callers would have common
  `RetryConfig` inside a static or const, so this may also avoid some
  additional cloning on the caller end.
  
  More generally, since we don't need ownership, asking for a reference
  allows for more global efficiency since the caller gets to use a
  reference if they have one.
  
  BREAKING CHANGE: The `Endpoint::send_message_with` and
  `Endpoint::try_send_message_with` methods now take `retries` as an
  `Option<&RetryConfig>`, rather than `Option<RetryConfig>`.

- 811edd5 **refactor: reorder `config` items so impls are next to types**


- 59b068e **refactor!: move `Endpoint::send_*` to `Connection`**

  `Endpoint::send_message[_with]` methods would open a connection if one
  doesn't exist, then send a message (over a unidirectional stream). These
  methods have been removed from `Endpoint`, and corresponding methods
  (`send[_with]`) have been added to `Connection`.
  
  This is another step towards having callers manage their own
  connections, so that we can remove the `ConnectionPool`. For now,
  callers can be updated trivially by chaining `Endpoint::connect_to`
  (which will look in the pool or create a new connection, and return it)
  and `Connection::send`, e.g.
  
      endpoint.connect_to(&addr).await?;
      endpoint.send_message(msg, &addr, 0).await?
  
  Becomes:
  
      endpoint
          .connect_to(&addr)
          .await?
          .send(msg)
          .await?
  
  BREAKING CHANGE: `Endpoint::send_message` and
  `Endpoint::send_message_with` have been removed. Use
  `Endpoint::connect_to` in combination with `Connection::send` or
  `Connection::send_with` instead.
