### PR TITLE
Yield `Connection` from `Incoming*` streams

### DIFF
--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -69,15 +69,13 @@ async fn main() -> Result<()> {
     println!("---\n");
 
     // loop over incoming messages
-    while let Some((socket_addr, bytes)) = incoming_messages.next().await {
-        println!("Received from {:?} --> {:?}", socket_addr, bytes);
+    while let Some((connection, bytes)) = incoming_messages.next().await {
+        let src = connection.remote_address();
+        println!("Received from {:?} --> {:?}", src, bytes);
         if bytes == *MSG_MARCO {
             let reply = Bytes::from(MSG_POLO);
-            node.connect_to(&socket_addr)
-                .await?
-                .send(reply.clone())
-                .await?;
-            println!("Replied to {:?} --> {:?}", socket_addr, reply);
+            connection.send(reply.clone()).await?;
+            println!("Replied to {:?} --> {:?}", src, reply);
         }
         println!();
     }

--- a/src/connection_pool.rs
+++ b/src/connection_pool.rs
@@ -132,10 +132,6 @@ impl<I: ConnId> ConnectionRemover<I> {
         let _ = store.id_map.remove(&self.id);
     }
 
-    pub(crate) fn remote_addr(&self) -> &SocketAddr {
-        &self.key.addr
-    }
-
     pub(crate) fn id(&self) -> I {
         self.id
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -39,8 +39,8 @@ impl ConnId for [u8; 32] {
 /// Construct an `Endpoint` with sane defaults for testing.
 pub(crate) async fn new_endpoint() -> Result<(
     Endpoint<[u8; 32]>,
-    IncomingConnections,
-    IncomingMessages,
+    IncomingConnections<[u8; 32]>,
+    IncomingMessages<[u8; 32]>,
     DisconnectionEvents,
     Option<Connection<[u8; 32]>>,
 )> {


### PR DESCRIPTION
- 5a0a7a8 **refactor!: remove `Endpoint::try_send_*`**

  The `try_send_*` methods exist to send messages using a connection that
  already exists in the pool. This is useful for sending messages to
  clients, since it would be impossible to connect to them in case a
  connection is not in the pool, so using `connect_to` would retry until
  failure.
  
  This use-case is now covered by the `Endpoint::get_connection_by_addr`
  method.
  
  BREAKING CHANGE: `Endpoint::try_send_message` and
  `Endpoint::try_send_message_with` have been removed. Use
  `Endpoint::get_connection_by_addr` and `Connection::send_*` instead.

- a0564f7 **refactor!: yield `Connection`s from `Incoming*` streams**

  This is a necessary API change on the path to allowing the
  `ConnectionPool` to be removed – it's would no longer be sufficient to
  yield the `SocketAddr`, since there would be no way of obtaining the
  associated `Connection`.
  
  Since the `ConnectionPool` yet remains, this is again an easy migration
  for callers, who can simply use `Connection::remote_address` and work
  with the pre-existing APIs.
  
  BREAKING CHANGE: `IncomingConnections::next` now returns
  `Option<Connection<I>>`. `IncomingMessages::next` now returns
  `Option<(Connection<I>, Bytes)>`.
