### PR TITLE
test: return errors in tests, don't just construct them

### DIFF
--- a/src/connections.rs
+++ b/src/connections.rs
@@ -497,7 +497,7 @@ async fn handle_endpoint_verification_req<I: ConnId>(
 #[cfg(test)]
 mod tests {
     use crate::{tests::new_endpoint, wire_msg::WireMsg};
-    use color_eyre::eyre::{eyre, Result};
+    use color_eyre::eyre::{bail, Result};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn echo_service() -> Result<()> {
@@ -524,7 +524,7 @@ mod tests {
         if let Some(WireMsg::EndpointEchoResp(addr)) = message {
             assert_eq!(addr, peer1_addr);
         } else {
-            eyre!("Unexpected response to EchoService request");
+            bail!("Unexpected response to EchoService request");
         }
         Ok(())
     }


### PR DESCRIPTION
- dc22356 **test: return errors in tests, don't just construct them**

  This is a bug that's been sitting for a while, and was even maintained
  in the conversion from `anyhow` -> `eyre`.
  
  Thankfully it was masking a single test failure, related to the
  behaviour of `disconnect_from` which was deliberately changed to close
  all connections to the peer back in 2bab0548, so this was just a case of
  updating the test.
