### PR TITLE
Implement a non-pooled `Connection` API

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump Version
-        uses: maidsafe/rust-version-bump-branch-creator@v2
+        uses: maidsafe/rust-version-bump-branch-creator@v3
         with:
           token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+          target_branch: master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,15 @@ authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 keywords = [ "quic" ]
 edition = "2018"
 
+[[example]]
+name = "p2p_node"
+required-features = ["unstable-opened-connection-count"]
+
 [features]
 default = [ "igd" ]
+
+# `unstable-` features may be removed at any time without a breaking change release
+unstable-opened-connection-count = []
 
 [dependencies]
 backoff = { version = "0.3.0", features = ["tokio"] }
@@ -25,6 +32,7 @@ quinn-proto = "0.7.3"
 rcgen = "~0.8.4"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
 serde = { version = "1.0.117", features = ["derive"] }
+stability = "0.1.0"
 thiserror = "1.0.23"
 tiny-keccak = "2.0.2"
 tokio = { version = "1.2.0", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,65 +11,32 @@ authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 keywords = [ "quic" ]
 edition = "2018"
 
+[features]
+default = [ "igd" ]
+
 [dependencies]
+backoff = { version = "0.3.0", features = ["tokio"] }
 bincode = "1.2.1"
+bytes = { version = "1.0.1", features = ["serde"] }
 futures = "~0.3.8"
+igd = { version = "0.12.0", optional = true, features = ["aio"] }
+quinn = { version = "0.7.0", default-features = false, features = ["tls-rustls"] }
 quinn-proto = "0.7.3"
 rcgen = "~0.8.4"
+rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
+serde = { version = "1.0.117", features = ["derive"] }
 thiserror = "1.0.23"
-webpki = "~0.21.3"
 tiny-keccak = "2.0.2"
+tokio = { version = "1.2.0", features = ["sync"] }
 tracing = "~0.1.26"
+webpki = "~0.21.3"
 xor_name = "3.1.0"
-
-  [dependencies.backoff]
-  version = "0.3.0"
-  features = [ "tokio" ]
-
-  [dependencies.bytes]
-  version = "1.0.1"
-  features = [ "serde" ]
-
-  [dependencies.igd]
-  version = "~0.12.0"
-  features = [ "aio" ]
-  optional = true
-
-  [dependencies.quinn]
-  version = "~0.7.0"
-  features = [ "tls-rustls" ]
-  default-features = false
-
-  [dependencies.rustls]
-  version = "~0.19.0"
-  features = [ "dangerous_configuration" ]
-
-  [dependencies.serde]
-  version = "1.0.117"
-  features = [ "derive" ]
-
-  [dependencies.tokio]
-  version = "1.2.0"
-  features = [
-  "rt",
-  "sync",
-  "time",
-  "macros",
-  "io-std",
-  "io-util",
-  "rt-multi-thread"
-]
 
 [dev-dependencies]
 color-eyre = "0.5.11"
 ctor = "0.1.20"
 rand = "~0.7.3"
-tracing-test = "0.1.0"
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
+tokio = { version = "1.2.0", features = ["macros"] }
 tracing-subscriber = "0.2.19"
-
-  [dev-dependencies.tiny-keccak]
-  version = "2.0.2"
-  features = [ "sha3" ]
-
-[features]
-default = [ "igd" ]
+tracing-test = "0.1.0"

--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -62,6 +62,11 @@ async fn main() -> Result<()> {
             println!("Sending to {:?} --> {:?}\n", peer, msg);
             node.connect_to(&peer).await?.send(msg.clone()).await?;
         }
+
+        println!(
+            "Done sending, opened {} connections",
+            node.opened_connection_count()
+        );
     }
 
     println!("\n---");

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,8 @@ pub const DEFAULT_RETRY_DELAY_RAND_FACTOR: f64 = 0.3;
 /// Default for [`RetryConfig::retrying_max_elapsed_time`] (30 s).
 pub const DEFAULT_RETRYING_MAX_ELAPSED_TIME: Duration = Duration::from_secs(30);
 
-const MAIDSAFE_DOMAIN: &str = "maidsafe.net";
+// We use a hard-coded server name for self-signed certificates.
+pub(crate) const SERVER_NAME: &str = "maidsafe.net";
 
 // Convenience alias – not for export.
 type Result<T, E = ConfigError> = std::result::Result<T, E>;
@@ -287,7 +288,7 @@ impl InternalConfig {
     }
 
     fn generate_cert() -> Result<(quinn::Certificate, quinn::PrivateKey)> {
-        let cert = rcgen::generate_simple_self_signed(vec![MAIDSAFE_DOMAIN.to_string()])?;
+        let cert = rcgen::generate_simple_self_signed(vec![SERVER_NAME.to_string()])?;
 
         let cert_der = cert.serialize_der()?;
         let key_der = cert.serialize_private_key_der();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,676 @@
+//! A message-oriented API wrapping the underlying QUIC library (`quinn`).
+
+use crate::{
+    config::SERVER_NAME,
+    error::{Close, ConnectionError, RecvError, RpcError, SendError, SerializationError},
+    wire_msg::WireMsg,
+};
+use bytes::Bytes;
+use futures::{
+    future,
+    stream::{self, StreamExt, TryStreamExt},
+};
+use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
+use tokio::{
+    sync::{mpsc, watch},
+    time::timeout,
+};
+use tracing::{trace, warn};
+
+// TODO: this seems arbitrary - it may need tuned or made configurable.
+const INCOMING_MESSAGE_BUFFER_LEN: usize = 10_000;
+
+// TODO: this seems arbitrary - it may need tuned or made configurable.
+const ENDPOINT_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The sending API for a connection.
+#[derive(Clone)]
+pub(crate) struct Connection {
+    inner: quinn::Connection,
+    alive_tx: Arc<watch::Sender<()>>,
+}
+
+impl Connection {
+    pub(crate) fn new(
+        endpoint: quinn::Endpoint,
+        connection: quinn::NewConnection,
+    ) -> (Connection, ConnectionIncoming) {
+        // this channel serves to keep the background message listener alive so long as one side of
+        // the connection API is alive.
+        let (alive_tx, alive_rx) = watch::channel(());
+        let alive_tx = Arc::new(alive_tx);
+        let peer_address = connection.connection.remote_address();
+
+        (
+            Self {
+                inner: connection.connection,
+                alive_tx: Arc::clone(&alive_tx),
+            },
+            ConnectionIncoming::new(
+                endpoint,
+                peer_address,
+                connection.uni_streams,
+                connection.bi_streams,
+                alive_tx,
+                alive_rx,
+            ),
+        )
+    }
+
+    /// The address of the remote peer.
+    pub(crate) fn remote_address(&self) -> SocketAddr {
+        self.inner.remote_address()
+    }
+
+    /// Open a unidirection stream to the peer.
+    ///
+    /// Messages sent over the stream will arrive at the peer in the order they were sent.
+    pub(crate) async fn open_uni(&self) -> Result<SendStream, ConnectionError> {
+        let send_stream = self.inner.open_uni().await?;
+        Ok(SendStream::new(send_stream))
+    }
+
+    /// Open a bidirectional stream to the peer.
+    ///
+    /// Bidirectional streams allow messages to be sent in both directions. This can be useful to
+    /// automatically correlate response messages, for example.
+    ///
+    /// Messages sent over the stream will arrive at the peer in the order they were sent.
+    pub(crate) async fn open_bi(&self) -> Result<(SendStream, RecvStream), ConnectionError> {
+        let (send_stream, recv_stream) = self.inner.open_bi().await?;
+        Ok((SendStream::new(send_stream), RecvStream::new(recv_stream)))
+    }
+
+    /// Close the connection immediately.
+    ///
+    /// This is not a graceful close - pending operations will fail immediately with
+    /// [`ConnectionError::Closed`]`(`[`Close::Local`]`)`, and data on unfinished streams is not
+    /// guaranteed to be delivered.
+    pub(crate) fn close(&self) {
+        self.inner.close(0u8.into(), b"");
+    }
+}
+
+/// The sending API for a QUIC stream.
+pub struct SendStream {
+    inner: quinn::SendStream,
+}
+
+impl SendStream {
+    fn new(inner: quinn::SendStream) -> Self {
+        Self { inner }
+    }
+
+    /// Set the priority of the send stream.
+    ///
+    /// Every send stream has an initial priority of 0. Locally buffered data from streams with
+    /// higher priority will be transmitted before data from streams with lower priority. Changing
+    /// the priority of a stream with pending data may only take effect after that data has been
+    /// transmitted. Using many different priority levels per connection may have a negative impact
+    /// on performance.
+    pub fn set_priority(&self, priority: i32) {
+        // quinn returns `UnknownStream` error if the stream does not exist. We ignore it, on the
+        // basis that operations on the stream will fail instead (and the effect of setting priority
+        // or not is only observable if the stream exists).
+        let _ = self.inner.set_priority(priority);
+    }
+
+    /// Send a message over the stream to the peer.
+    ///
+    /// Messages sent over the stream will arrive at the peer in the order they were sent.
+    pub async fn send_user_msg(&mut self, msg: Bytes) -> Result<(), SendError> {
+        WireMsg::UserMsg(msg).write_to_stream(&mut self.inner).await
+    }
+
+    /// Shut down the send stream gracefully.
+    ///
+    /// The returned future will complete once the peer has acknowledged all sent data.
+    pub async fn finish(&mut self) -> Result<(), SendError> {
+        self.inner.finish().await?;
+        Ok(())
+    }
+
+    pub(crate) async fn send_wire_msg(&mut self, msg: WireMsg) -> Result<(), SendError> {
+        msg.write_to_stream(&mut self.inner).await
+    }
+}
+
+impl fmt::Debug for SendStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SendStream").finish_non_exhaustive()
+    }
+}
+
+/// The receiving API for a bidirectional QUIC stream.
+pub struct RecvStream {
+    inner: quinn::RecvStream,
+}
+
+impl RecvStream {
+    fn new(inner: quinn::RecvStream) -> Self {
+        Self { inner }
+    }
+
+    /// Get the next message sent by the peer over this stream.
+    pub async fn next(&mut self) -> Result<Bytes, RecvError> {
+        match self.next_wire_msg().await? {
+            Some(WireMsg::UserMsg(msg)) => Ok(msg),
+            msg => Err(SerializationError::unexpected(msg).into()),
+        }
+    }
+
+    pub(crate) async fn next_wire_msg(&mut self) -> Result<Option<WireMsg>, RecvError> {
+        WireMsg::read_from_stream(&mut self.inner).await
+    }
+}
+
+impl fmt::Debug for RecvStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("RecvStream").finish_non_exhaustive()
+    }
+}
+
+/// The receiving API for a connection.
+pub(crate) struct ConnectionIncoming {
+    message_rx: mpsc::Receiver<Result<Bytes, RecvError>>,
+    _alive_tx: Arc<watch::Sender<()>>,
+}
+
+impl ConnectionIncoming {
+    fn new(
+        endpoint: quinn::Endpoint,
+        peer_addr: SocketAddr,
+        uni_streams: quinn::IncomingUniStreams,
+        bi_streams: quinn::IncomingBiStreams,
+        alive_tx: Arc<watch::Sender<()>>,
+        alive_rx: watch::Receiver<()>,
+    ) -> Self {
+        let (message_tx, message_rx) = mpsc::channel(INCOMING_MESSAGE_BUFFER_LEN);
+
+        // offload the actual message handling to a background task - the task will exit when
+        // `alive_tx` is dropped, which would be when both sides of the connection are dropped.
+        start_message_listeners(
+            endpoint,
+            peer_addr,
+            uni_streams,
+            bi_streams,
+            alive_rx,
+            message_tx,
+        );
+
+        Self {
+            message_rx,
+            _alive_tx: alive_tx,
+        }
+    }
+
+    /// Get the next message sent by the peer, over any stream.
+    pub(crate) async fn next(&mut self) -> Result<Option<Bytes>, RecvError> {
+        self.message_rx.recv().await.transpose()
+    }
+}
+
+// Start listeners in background tokio tasks. These tasks will run until they terminate, which would
+// be when the connection terminates, or all connection handles are dropped.
+//
+// `alive_tx` is used to detect when all connection handles are dropped.
+// `message_tx` is used to exfiltrate messages and stream errors.
+fn start_message_listeners(
+    endpoint: quinn::Endpoint,
+    peer_addr: SocketAddr,
+    uni_streams: quinn::IncomingUniStreams,
+    bi_streams: quinn::IncomingBiStreams,
+    alive_rx: watch::Receiver<()>,
+    message_tx: mpsc::Sender<Result<Bytes, RecvError>>,
+) {
+    let _ = tokio::spawn(listen_on_uni_streams(
+        peer_addr,
+        uni_streams,
+        alive_rx.clone(),
+        message_tx.clone(),
+    ));
+
+    let _ = tokio::spawn(listen_on_bi_streams(
+        endpoint, peer_addr, bi_streams, alive_rx, message_tx,
+    ));
+}
+
+async fn listen_on_uni_streams(
+    peer_addr: SocketAddr,
+    uni_streams: quinn::IncomingUniStreams,
+    mut alive_rx: watch::Receiver<()>,
+    message_tx: mpsc::Sender<Result<Bytes, RecvError>>,
+) {
+    trace!(
+        "Started listener for incoming uni-streams from {}",
+        peer_addr
+    );
+
+    let mut uni_messages = Box::pin(
+        uni_streams
+            .map_ok(|recv_stream| {
+                trace!("Handling incoming uni-stream from {}", peer_addr);
+
+                stream::try_unfold(recv_stream, |mut recv_stream| async move {
+                    WireMsg::read_from_stream(&mut recv_stream)
+                        .await
+                        .and_then(|msg| match msg {
+                            Some(WireMsg::UserMsg(msg)) => Ok(Some((msg, recv_stream))),
+                            None => Ok(None),
+                            _ => Err(SerializationError::unexpected(msg).into()),
+                        })
+                })
+            })
+            .try_flatten(),
+    );
+
+    // it's a shame to allocate, but there are `Pin` errors otherwise – and we should only be doing
+    // this once (per connection).
+    let mut alive = Box::pin(alive_rx.changed());
+
+    while let Some(result) = {
+        match future::select(uni_messages.next(), &mut alive).await {
+            future::Either::Left((result, _)) => result,
+            future::Either::Right((Ok(_), pending_message)) => {
+                // we don't expect to actually send a value over the alive channel, so just ignore
+                pending_message.await
+            }
+            future::Either::Right((Err(_), _)) => {
+                // the connection has been dropped
+                // TODO: should we just drop pending messages here? if not, how long do we wait?
+                trace!(
+                    "Stopped listener for incoming uni-streams from {}: connection handles dropped",
+                    peer_addr
+                );
+                None
+            }
+        }
+    } {
+        if message_tx.send(result).await.is_err() {
+            // if we can't send the result, the receiving end is closed so we should stop
+            break;
+        }
+    }
+    trace!(
+        "Stopped listener for incoming uni-streams from {}: stream finished",
+        peer_addr
+    );
+}
+
+async fn listen_on_bi_streams(
+    endpoint: quinn::Endpoint,
+    peer_addr: SocketAddr,
+    bi_streams: quinn::IncomingBiStreams,
+    mut alive_rx: watch::Receiver<()>,
+    message_tx: mpsc::Sender<Result<Bytes, RecvError>>,
+) {
+    trace!(
+        "Started listener for incoming bi-streams from {}",
+        peer_addr
+    );
+
+    let streaming =
+        bi_streams.try_for_each_concurrent(None, |(mut send_stream, mut recv_stream)| {
+            let endpoint = &endpoint;
+            let message_tx = &message_tx;
+            async move {
+                trace!("Handling incoming uni-stream from {}", peer_addr);
+
+                loop {
+                    match WireMsg::read_from_stream(&mut recv_stream).await {
+                        Err(error) => {
+                            if let Err(error) = message_tx.send(Err(error)).await {
+                                // if we can't send the result, the receiving end is closed so we should stop
+                                trace!("Receiver gone, dropping error: {:?}", error);
+                                break;
+                            }
+                        }
+                        Ok(None) => {
+                            break;
+                        }
+                        Ok(Some(WireMsg::UserMsg(msg))) => {
+                            if let Err(msg) = message_tx.send(Ok(msg)).await {
+                                // if we can't send the result, the receiving end is closed so we should stop
+                                trace!("Receiver gone, dropping message: {:?}", msg);
+                                break;
+                            }
+                        }
+                        Ok(Some(WireMsg::EndpointEchoReq)) => {
+                            if let Err(error) =
+                                handle_endpoint_echo(&mut send_stream, peer_addr).await
+                            {
+                                // TODO: consider more carefully how to handle this
+                                warn!("Error handling endpoint echo request: {}", error);
+                            }
+                        }
+                        Ok(Some(WireMsg::EndpointVerificationReq(addr))) => {
+                            if let Err(error) =
+                                handle_endpoint_verification(endpoint, &mut send_stream, addr).await
+                            {
+                                // TODO: consider more carefully how to handle this
+                                warn!("Error handling endpoint verification request: {}", error);
+                            }
+                        }
+                        Ok(msg) => {
+                            // TODO: consider more carefully how to handle this
+                            warn!(
+                                "Error on bi-stream: {}",
+                                SerializationError::unexpected(msg)
+                            );
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        });
+
+    // it's a shame to allocate, but there are `Pin` errors otherwise – and we should only be doing
+    // this once.
+    let mut alive = Box::pin(alive_rx.changed());
+
+    match future::select(streaming, &mut alive).await {
+        future::Either::Left((Ok(()), _)) => {
+            trace!(
+                "Stopped listener for incoming bi-streams from {}: stream ended",
+                peer_addr
+            );
+        }
+        future::Either::Left((Err(error), _)) => {
+            match error.into() {
+                ConnectionError::Closed(Close::Local) => {
+                    trace!(
+                        "Stopped listener for incoming bi-streams from {}: connection closed locally",
+                        peer_addr
+                    );
+                }
+                ConnectionError::Closed(Close::Application {
+                    error_code: 0,
+                    reason,
+                }) => {
+                    trace!(
+                        "Stopped listener for incoming bi-streams from {}: closed by peer (error code: 0, reason: {:?})",
+                        peer_addr,
+                        String::from_utf8_lossy(&reason)
+                    );
+                }
+                error => {
+                    // TODO: consider more carefully how to handle this
+                    warn!(
+                        "Stopped listener for incoming bi-streams from {} due to error: {:?}",
+                        peer_addr, error
+                    );
+                }
+            }
+        }
+        future::Either::Right((_, _)) => {
+            // the connection was closed
+            // TODO: should we just drop pending messages here? if not, how long do we wait?
+            trace!(
+                "Stopped listener for incoming bi-streams from {}: connection handles dropped",
+                peer_addr
+            );
+        }
+    }
+}
+
+async fn handle_endpoint_echo(
+    send_stream: &mut quinn::SendStream,
+    peer_addr: SocketAddr,
+) -> Result<(), SendError> {
+    WireMsg::EndpointEchoResp(peer_addr)
+        .write_to_stream(send_stream)
+        .await
+}
+
+async fn handle_endpoint_verification(
+    endpoint: &quinn::Endpoint,
+    send_stream: &mut quinn::SendStream,
+    addr: SocketAddr,
+) -> Result<(), SendError> {
+    let verify = async {
+        let connection = endpoint
+            .connect(&addr, SERVER_NAME)
+            .map_err(ConnectionError::from)?
+            .await?;
+
+        let (mut send_stream, mut recv_stream) = connection.connection.open_bi().await?;
+        WireMsg::EndpointEchoReq
+            .write_to_stream(&mut send_stream)
+            .await?;
+
+        match WireMsg::read_from_stream(&mut recv_stream).await? {
+            Some(WireMsg::EndpointEchoResp(_)) => Ok(()),
+            msg => Err(RecvError::from(SerializationError::unexpected(msg)).into()),
+        }
+    };
+
+    let verified: Result<_, RpcError> = timeout(ENDPOINT_VERIFICATION_TIMEOUT, verify)
+        .await
+        .unwrap_or_else(|error| Err(error.into()));
+
+    if let Err(error) = &verified {
+        warn!("Endpoint verification for {} failed: {:?}", addr, error);
+    }
+
+    WireMsg::EndpointVerificationResp(verified.is_ok())
+        .write_to_stream(send_stream)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Connection;
+    use crate::{
+        config::{InternalConfig, SERVER_NAME},
+        tests::local_addr,
+        wire_msg::WireMsg,
+    };
+    use bytes::Bytes;
+    use color_eyre::eyre::{bail, Result};
+    use futures::{StreamExt, TryStreamExt};
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn basic_usage() -> Result<()> {
+        let config = InternalConfig::try_from_config(Default::default())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer1, _) = builder.bind(&local_addr())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer2, peer2_incoming) = builder.bind(&local_addr())?;
+
+        {
+            let (p1_tx, mut p1_rx) = Connection::new(
+                peer1.clone(),
+                peer1.connect(&peer2.local_addr()?, SERVER_NAME)?.await?,
+            );
+
+            let (p2_tx, mut p2_rx) =
+                if let Some(connection) = timeout(peer2_incoming.then(|c| c).try_next()).await?? {
+                    Connection::new(peer2.clone(), connection)
+                } else {
+                    bail!("did not receive incoming connection when one was expected");
+                };
+
+            p1_tx
+                .open_uni()
+                .await?
+                .send_user_msg(Bytes::from_static(b"hello"))
+                .await?;
+
+            if let Some(msg) = timeout(p2_rx.next()).await?? {
+                assert_eq!(&msg[..], b"hello");
+            } else {
+                bail!("did not receive message when one was expected");
+            }
+
+            p2_tx
+                .open_uni()
+                .await?
+                .send_user_msg(Bytes::from_static(b"world"))
+                .await?;
+
+            if let Some(msg) = timeout(p1_rx.next()).await?? {
+                assert_eq!(&msg[..], b"world");
+            } else {
+                bail!("did not receive message when one was expected");
+            }
+        }
+
+        // check the connections were shutdown on drop
+        timeout(peer1.wait_idle()).await?;
+        timeout(peer2.wait_idle()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn endpoint_echo() -> Result<()> {
+        let config = InternalConfig::try_from_config(Default::default())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer1, _) = builder.bind(&local_addr())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer2, peer2_incoming) = builder.bind(&local_addr())?;
+
+        {
+            let (p1_tx, _) = Connection::new(
+                peer1.clone(),
+                peer1.connect(&peer2.local_addr()?, SERVER_NAME)?.await?,
+            );
+
+            // we need to accept the connection on p2, or the message won't be processed
+            let _p2_handle =
+                if let Some(connection) = timeout(peer2_incoming.then(|c| c).try_next()).await?? {
+                    Connection::new(peer2.clone(), connection)
+                } else {
+                    bail!("did not receive incoming connection when one was expected");
+                };
+
+            let (mut send_stream, mut recv_stream) = p1_tx.open_bi().await?;
+            send_stream.send_wire_msg(WireMsg::EndpointEchoReq).await?;
+
+            if let Some(msg) = timeout(recv_stream.next_wire_msg()).await?? {
+                if let WireMsg::EndpointEchoResp(addr) = msg {
+                    assert_eq!(addr, peer1.local_addr()?);
+                } else {
+                    bail!(
+                        "received unexpected message when EndpointEchoResp was expected: {:?}",
+                        msg
+                    );
+                }
+            } else {
+                bail!("did not receive incoming message when one was expected");
+            }
+        }
+
+        // check the connections were shutdown on drop
+        timeout(peer1.wait_idle()).await?;
+        timeout(peer2.wait_idle()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn endpoint_verification() -> Result<()> {
+        let config = InternalConfig::try_from_config(Default::default())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer1, peer1_incoming) = builder.bind(&local_addr())?;
+
+        let mut builder = quinn::Endpoint::builder();
+        let _ = builder
+            .listen(config.server.clone())
+            .default_client_config(config.client.clone());
+        let (peer2, peer2_incoming) = builder.bind(&local_addr())?;
+
+        {
+            let (p1_tx, _) = Connection::new(
+                peer1.clone(),
+                peer1.connect(&peer2.local_addr()?, SERVER_NAME)?.await?,
+            );
+
+            // we need to accept the connection on p2, or the message won't be processed
+            let _p2_handle =
+                if let Some(connection) = timeout(peer2_incoming.then(|c| c).try_next()).await?? {
+                    Connection::new(peer2.clone(), connection)
+                } else {
+                    bail!("did not receive incoming connection when one was expected");
+                };
+
+            let (mut send_stream, mut recv_stream) = p1_tx.open_bi().await?;
+            send_stream
+                .send_wire_msg(WireMsg::EndpointVerificationReq(peer1.local_addr()?))
+                .await?;
+
+            // we need to accept the connection on p1, or the message won't be processed
+            let _p1_handle =
+                if let Some(connection) = timeout(peer1_incoming.then(|c| c).try_next()).await?? {
+                    Connection::new(peer1.clone(), connection)
+                } else {
+                    bail!("did not receive incoming connection when one was expected");
+                };
+
+            if let Some(msg) = timeout(recv_stream.next_wire_msg()).await?? {
+                if let WireMsg::EndpointVerificationResp(true) = msg {
+                } else {
+                    bail!(
+                        "received unexpected message when EndpointVerificationResp(true) was expected: {:?}",
+                        msg
+                    );
+                }
+            } else {
+                bail!("did not receive incoming message when one was expected");
+            }
+
+            send_stream
+                .send_wire_msg(WireMsg::EndpointVerificationReq(local_addr()))
+                .await?;
+
+            if let Some(msg) = timeout(recv_stream.next_wire_msg()).await?? {
+                if let WireMsg::EndpointVerificationResp(false) = msg {
+                } else {
+                    bail!(
+                        "received unexpected message when EndpointVerificationResp(false) was expected: {:?}",
+                        msg
+                    );
+                }
+            } else {
+                bail!("did not receive incoming message when one was expected");
+            }
+        }
+
+        // check the connections were shutdown on drop
+        timeout(peer1.wait_idle()).await?;
+        timeout(peer2.wait_idle()).await?;
+
+        Ok(())
+    }
+
+    async fn timeout<F: std::future::Future>(
+        f: F,
+    ) -> Result<F::Output, tokio::time::error::Elapsed> {
+        tokio::time::timeout(std::time::Duration::from_millis(500), f).await
+    }
+}

--- a/src/connection_handle.rs
+++ b/src/connection_handle.rs
@@ -9,15 +9,16 @@
 
 use super::{
     connection_pool::{ConnId, ConnectionPool, ConnectionRemover},
-    error::{ConnectionError, RecvError, RpcError, SendError, SerializationError},
-    wire_msg::WireMsg,
+    error::{ConnectionError, SendError, StreamError},
 };
-use crate::{Endpoint, RetryConfig};
+use crate::{
+    connection::{Connection, ConnectionIncoming, RecvStream, SendStream},
+    Endpoint, RetryConfig,
+};
 use bytes::Bytes;
-use futures::{future, stream::StreamExt};
+use futures::stream::StreamExt;
 use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::time::{timeout, Duration};
 use tracing::{trace, warn};
 
 /// A connection between two [`Endpoint`]s.
@@ -32,7 +33,7 @@ use tracing::{trace, warn};
 /// [`Endpoint::connect_to`]: crate::Endpoint::connect_to
 #[derive(Clone)]
 pub struct ConnectionHandle<I: ConnId> {
-    quic_conn: quinn::Connection,
+    inner: Connection,
     default_retry_config: Arc<RetryConfig>,
     remover: ConnectionRemover<I>,
 }
@@ -51,12 +52,12 @@ impl DisconnectionEvents {
 
 impl<I: ConnId> ConnectionHandle<I> {
     pub(crate) fn new(
-        quic_conn: quinn::Connection,
+        inner: Connection,
         default_retry_config: Arc<RetryConfig>,
         remover: ConnectionRemover<I>,
     ) -> Self {
         Self {
-            quic_conn,
+            inner,
             default_retry_config,
             remover,
         }
@@ -69,7 +70,7 @@ impl<I: ConnId> ConnectionHandle<I> {
 
     /// Get the address of the connected peer.
     pub fn remote_address(&self) -> SocketAddr {
-        self.quic_conn.remote_address()
+        self.inner.remote_address()
     }
 
     /// Send a message to the peer with default configuration.
@@ -107,30 +108,29 @@ impl<I: ConnId> ConnectionHandle<I> {
         &self,
         priority: i32,
     ) -> Result<(SendStream, RecvStream), ConnectionError> {
-        let (send_stream, recv_stream) = self.handle_error(self.quic_conn.open_bi().await).await?;
-        let send_stream = SendStream::new(send_stream);
+        let (send_stream, recv_stream) = self.handle_error(self.inner.open_bi().await).await?;
         send_stream.set_priority(priority);
-        Ok((send_stream, RecvStream::new(recv_stream)))
+        Ok((send_stream, recv_stream))
     }
 
     /// Send message to peer using a uni-directional stream.
     /// Priority default is 0. Both lower and higher can be passed in.
     pub(crate) async fn send_uni(&self, msg: Bytes, priority: i32) -> Result<(), SendError> {
-        let mut send_stream = self.handle_error(self.quic_conn.open_uni().await).await?;
+        let mut send_stream = self.handle_error(self.inner.open_uni().await).await?;
 
         // quinn returns `UnknownStream` error if the stream does not exist. We ignore it, on the
         // basis that operations on the stream will fail instead (and the effect of setting priority
         // or not is only observable if the stream exists).
         let _ = send_stream.set_priority(priority);
 
-        self.handle_error(send_msg(&mut send_stream, msg).await)
+        self.handle_error(send_stream.send_user_msg(msg).await)
             .await?;
 
         // We try to make sure the stream is gracefully closed and the bytes get sent,
         // but if it was already closed (perhaps by the peer) then we
         // don't remove the connection from the pool.
         match send_stream.finish().await {
-            Ok(()) | Err(quinn::WriteError::Stopped(_)) => Ok(()),
+            Ok(()) | Err(SendError::StreamLost(StreamError::Stopped(_))) => Ok(()),
             Err(err) => {
                 self.handle_error(Err(err)).await?;
                 Ok(())
@@ -147,95 +147,6 @@ impl<I: ConnId> ConnectionHandle<I> {
     }
 }
 
-/// Stream to receive multiple messages
-pub struct RecvStream {
-    pub(crate) quinn_recv_stream: quinn::RecvStream,
-}
-
-impl RecvStream {
-    pub(crate) fn new(quinn_recv_stream: quinn::RecvStream) -> Self {
-        Self { quinn_recv_stream }
-    }
-
-    /// Read next user message from the stream
-    pub async fn next(&mut self) -> Result<Bytes, RecvError> {
-        match self.next_wire_msg().await? {
-            Some(WireMsg::UserMsg(bytes)) => Ok(bytes),
-            msg => Err(SerializationError::unexpected(msg).into()),
-        }
-    }
-
-    /// Read next wire msg from the stream
-    pub(crate) async fn next_wire_msg(&mut self) -> Result<Option<WireMsg>, RecvError> {
-        read_bytes(&mut self.quinn_recv_stream).await
-    }
-}
-
-impl Debug for RecvStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "RecvStream {{ .. }} ")
-    }
-}
-
-/// Stream of outgoing messages
-pub struct SendStream {
-    pub(crate) quinn_send_stream: quinn::SendStream,
-}
-
-impl SendStream {
-    pub(crate) fn new(quinn_send_stream: quinn::SendStream) -> Self {
-        Self { quinn_send_stream }
-    }
-
-    /// Set the priority of the send stream
-    ///
-    /// Every send stream has an initial priority of 0. Locally buffered data from streams with
-    /// higher priority will be transmitted before data from streams with lower priority. Changing
-    /// the priority of a stream with pending data may only take effect after that data has been
-    /// transmitted. Using many different priority levels per connection may have a negative
-    /// impact on performance.
-    pub fn set_priority(&self, priority: i32) {
-        // quinn returns `UnknownStream` error if the stream does not exist. We ignore it, on the
-        // basis that operations on the stream will fail instead (and the effect of setting priority
-        // or not is only observable if the stream exists).
-        let _ = self.quinn_send_stream.set_priority(priority);
-    }
-
-    /// Send a message using the stream created by the initiator
-    pub async fn send_user_msg(&mut self, msg: Bytes) -> Result<(), SendError> {
-        send_msg(&mut self.quinn_send_stream, msg).await
-    }
-
-    /// Send a wire message
-    pub(crate) async fn send(&mut self, msg: WireMsg) -> Result<(), SendError> {
-        msg.write_to_stream(&mut self.quinn_send_stream).await
-    }
-
-    /// Gracefully finish current stream
-    pub async fn finish(mut self) -> Result<(), SendError> {
-        self.quinn_send_stream.finish().await?;
-        Ok(())
-    }
-}
-
-impl Debug for SendStream {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "SendStream {{ .. }} ")
-    }
-}
-
-// Helper to read the message's bytes from the provided stream
-async fn read_bytes(recv: &mut quinn::RecvStream) -> Result<Option<WireMsg>, RecvError> {
-    WireMsg::read_from_stream(recv).await
-}
-
-// Helper to send bytes to peer using the provided stream.
-async fn send_msg(mut send_stream: &mut quinn::SendStream, msg: Bytes) -> Result<(), SendError> {
-    let wire_msg = WireMsg::UserMsg(msg);
-    wire_msg.write_to_stream(&mut send_stream).await?;
-    Ok(())
-}
-
 pub(super) fn listen_for_incoming_connections<I: ConnId>(
     mut quinn_incoming: quinn::Incoming,
     connection_pool: ConnectionPool<I>,
@@ -243,17 +154,16 @@ pub(super) fn listen_for_incoming_connections<I: ConnId>(
     connection_tx: Sender<ConnectionHandle<I>>,
     disconnection_tx: Sender<SocketAddr>,
     endpoint: Endpoint<I>,
+    quic_endpoint: quinn::Endpoint,
 ) {
     let _ = tokio::spawn(async move {
         loop {
             match quinn_incoming.next().await {
                 Some(quinn_conn) => match quinn_conn.await {
-                    Ok(quinn::NewConnection {
-                        connection,
-                        uni_streams,
-                        bi_streams,
-                        ..
-                    }) => {
+                    Ok(connection) => {
+                        let (connection, connection_incoming) =
+                            Connection::new(quic_endpoint.clone(), connection);
+
                         let peer_address = connection.remote_address();
                         let id = ConnId::generate(&peer_address);
                         let pool_handle = connection_pool
@@ -263,11 +173,9 @@ pub(super) fn listen_for_incoming_connections<I: ConnId>(
                         let _ = connection_tx.send(connection.clone()).await;
                         listen_for_incoming_messages(
                             connection,
-                            uni_streams,
-                            bi_streams,
+                            connection_incoming,
                             message_tx.clone(),
                             disconnection_tx.clone(),
-                            endpoint.clone(),
                         );
                     }
                     Err(err) => {
@@ -285,247 +193,30 @@ pub(super) fn listen_for_incoming_connections<I: ConnId>(
 
 pub(super) fn listen_for_incoming_messages<I: ConnId>(
     connection: ConnectionHandle<I>,
-    mut uni_streams: quinn::IncomingUniStreams,
-    mut bi_streams: quinn::IncomingBiStreams,
+    mut connection_incoming: ConnectionIncoming,
     message_tx: Sender<(ConnectionHandle<I>, Bytes)>,
     disconnection_tx: Sender<SocketAddr>,
-    endpoint: Endpoint<I>,
 ) {
-    let src = connection.remote_address();
     let _ = tokio::spawn(async move {
-        match future::try_join(
-            read_on_uni_streams(&connection, &mut uni_streams, message_tx.clone()),
-            read_on_bi_streams(&connection, &mut bi_streams, message_tx, &endpoint),
-        )
-        .await
-        {
-            Ok(_) => {
-                connection.remover.remove().await;
-                let _ = disconnection_tx.send(src).await;
-            }
-            Err(error) => {
-                trace!("Issue on stream reading from: {:?} :: {:?}", src, error);
-                connection.remover.remove().await;
-                let _ = disconnection_tx.send(src).await;
+        let src = connection.remote_address();
+        loop {
+            match connection_incoming.next().await {
+                Ok(Some(msg)) => {
+                    let _ = message_tx.send((connection.clone(), msg)).await;
+                }
+                Ok(None) => {
+                    break;
+                }
+                Err(error) => {
+                    trace!("Issue on stream reading from {}: {:?}", src, error);
+                    break;
+                }
             }
         }
 
-        trace!("The connection to {:?} has been terminated.", src);
+        connection.remover.remove().await;
+        let _ = disconnection_tx.send(src).await;
+
+        trace!("The connection to {} has terminated", src);
     });
-}
-
-// unify uni- and bi-stream errors
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-enum StreamError {
-    Uni(#[from] RecvError),
-    Bi(#[from] RpcError),
-}
-
-// Read messages sent by peer in an unidirectional stream.
-async fn read_on_uni_streams<I: ConnId>(
-    connection: &ConnectionHandle<I>,
-    uni_streams: &mut quinn::IncomingUniStreams,
-    message_tx: Sender<(ConnectionHandle<I>, Bytes)>,
-) -> Result<(), StreamError> {
-    let peer_addr = connection.remote_address();
-    while let Some(result) = uni_streams.next().await {
-        match result {
-            Err(error @ quinn::ConnectionError::ConnectionClosed(_)) => {
-                trace!("Connection closed by peer {:?}", peer_addr);
-                return Err(StreamError::Uni(error.into()));
-            }
-            Err(error @ quinn::ConnectionError::ApplicationClosed(_)) => {
-                trace!("Connection closed by peer {:?}.", peer_addr);
-                return Err(StreamError::Uni(error.into()));
-            }
-            Err(err) => {
-                warn!(
-                    "Failed to read incoming message on uni-stream for peer {:?} with: {:?}",
-                    peer_addr, err
-                );
-                return Err(StreamError::Uni(err.into()));
-            }
-            Ok(mut recv) => {
-                while let Some(res) = read_bytes(&mut recv).await.transpose() {
-                    match res {
-                        Ok(WireMsg::UserMsg(bytes)) => {
-                            trace!("bytes received fine from: {:?} ", peer_addr);
-                            let _ = message_tx.send((connection.clone(), bytes)).await;
-                        }
-                        Ok(msg) => warn!("Unexpected message type: {:?}", msg),
-                        Err(err) => {
-                            warn!(
-                                "Failed reading from a uni-stream for peer {:?} with: {:?}",
-                                peer_addr, err
-                            );
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-// Read messages sent by peer in a bidirectional stream.
-async fn read_on_bi_streams<I: ConnId>(
-    connection: &ConnectionHandle<I>,
-    bi_streams: &mut quinn::IncomingBiStreams,
-    message_tx: Sender<(ConnectionHandle<I>, Bytes)>,
-    endpoint: &Endpoint<I>,
-) -> Result<(), StreamError> {
-    let peer_addr = connection.remote_address();
-    while let Some(result) = bi_streams.next().await {
-        match result {
-            Err(error @ quinn::ConnectionError::ConnectionClosed(_)) => {
-                trace!("Connection closed by peer {:?}", peer_addr);
-                return Err(StreamError::Bi(error.into()));
-            }
-            Err(error @ quinn::ConnectionError::ApplicationClosed(_)) => {
-                trace!("Connection closed by peer {:?}.", peer_addr);
-                return Err(StreamError::Bi(error.into()));
-            }
-            Err(err) => {
-                warn!(
-                    "Failed to read incoming message on bi-stream for peer {:?} with: {:?}",
-                    peer_addr, err
-                );
-                return Err(StreamError::Bi(err.into()));
-            }
-            Ok((mut send, mut recv)) => {
-                while let Some(res) = read_bytes(&mut recv).await.transpose() {
-                    match res {
-                        Ok(WireMsg::UserMsg(bytes)) => {
-                            let _ = message_tx.send((connection.clone(), bytes)).await;
-                        }
-                        Ok(WireMsg::EndpointEchoReq) => {
-                            if let Err(error) = handle_endpoint_echo_req(peer_addr, &mut send).await
-                            {
-                                warn!(
-                                    "Failed to handle Echo Request for peer {:?} with: {:?}",
-                                    peer_addr, error
-                                );
-
-                                return Err(StreamError::Bi(error.into()));
-                            }
-                        }
-                        Ok(WireMsg::EndpointVerificationReq(address_sent)) => {
-                            if let Err(error) = handle_endpoint_verification_req(
-                                peer_addr,
-                                address_sent,
-                                &mut send,
-                                endpoint,
-                            )
-                            .await
-                            {
-                                warn!("Failed to handle Endpoint verification request for peer {:?} with: {:?}", peer_addr, error);
-
-                                return Err(StreamError::Bi(error));
-                            }
-                        }
-                        Ok(msg) => {
-                            warn!(
-                                "Unexpected message type from peer {:?}: {:?}",
-                                peer_addr, msg
-                            );
-                        }
-                        Err(err) => {
-                            warn!(
-                                "Failed reading from a bi-stream for peer {:?} with: {:?}",
-                                peer_addr, err
-                            );
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn handle_endpoint_echo_req(
-    peer_addr: SocketAddr,
-    send_stream: &mut quinn::SendStream,
-) -> Result<(), SendError> {
-    trace!("Received Echo Request from peer {:?}", peer_addr);
-    let message = WireMsg::EndpointEchoResp(peer_addr);
-    message.write_to_stream(send_stream).await?;
-    trace!("Responded to Echo request from peer {:?}", peer_addr);
-    Ok(())
-}
-
-async fn handle_endpoint_verification_req<I: ConnId>(
-    peer_addr: SocketAddr,
-    addr_sent: SocketAddr,
-    send_stream: &mut quinn::SendStream,
-    endpoint: &Endpoint<I>,
-) -> Result<(), RpcError> {
-    trace!(
-        "Received Endpoint verification request {:?} from {:?}",
-        addr_sent,
-        peer_addr
-    );
-    // Verify if the peer's endpoint is reachable via EchoServiceReq
-    let (mut temp_send, mut temp_recv) = endpoint.open_bidirectional_stream(&addr_sent, 0).await?;
-    let message = WireMsg::EndpointEchoReq;
-    message
-        .write_to_stream(&mut temp_send.quinn_send_stream)
-        .await?;
-    let verified = matches!(
-        timeout(
-            Duration::from_secs(30),
-            WireMsg::read_from_stream(&mut temp_recv.quinn_recv_stream)
-        )
-        .await,
-        Ok(Ok(Some(WireMsg::EndpointEchoResp(_))))
-    );
-
-    let message = WireMsg::EndpointVerificationResp(verified);
-    message.write_to_stream(send_stream).await?;
-    trace!(
-        "Responded to Endpoint verification request from {:?}",
-        peer_addr
-    );
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{tests::new_endpoint, wire_msg::WireMsg};
-    use color_eyre::eyre::{bail, Result};
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn echo_service() -> Result<()> {
-        // Create Endpoint
-        let (peer1, mut peer1_connections, _, _, _) = new_endpoint().await?;
-        let peer1_addr = peer1.public_addr();
-
-        let (peer2, _, _, _, _) = new_endpoint().await?;
-        let peer2_addr = peer2.public_addr();
-
-        let _ = peer2.connect_to(&peer1_addr).await?;
-
-        if let Some(connection) = peer1_connections.next().await {
-            assert_eq!(connection.remote_address(), peer2_addr);
-        }
-
-        let connection = peer1.connect_to(&peer2_addr).await?;
-        let (mut send_stream, mut recv_stream) = connection.open_bi(0).await?;
-        let message = WireMsg::EndpointEchoReq;
-        message
-            .write_to_stream(&mut send_stream.quinn_send_stream)
-            .await?;
-        let message = WireMsg::read_from_stream(&mut recv_stream.quinn_recv_stream).await?;
-        if let Some(WireMsg::EndpointEchoResp(addr)) = message {
-            assert_eq!(addr, peer1_addr);
-        } else {
-            bail!("Unexpected response to EchoService request");
-        }
-        Ok(())
-    }
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -11,7 +11,7 @@
 use super::igd::{forward_port, IgdError};
 use super::wire_msg::WireMsg;
 use super::{
-    config::{Config, InternalConfig},
+    config::{Config, InternalConfig, SERVER_NAME},
     connection_deduplicator::{ConnectionDeduplicator, DedupHandle},
     connection_pool::{ConnId, ConnectionPool, ConnectionRemover},
     connections::{
@@ -35,10 +35,6 @@ use tokio::sync::broadcast::{self, Sender};
 use tokio::sync::mpsc::{self, Receiver as MpscReceiver, Sender as MpscSender};
 use tokio::time::{timeout, Duration};
 use tracing::{debug, error, info, trace, warn};
-
-/// Host name of the Quic communication certificate used by peers
-// FIXME: make it configurable
-const CERT_SERVER_NAME: &str = "MaidSAFE.net";
 
 // Number of seconds before timing out the IGD request to forward a port.
 #[cfg(feature = "igd")]
@@ -497,7 +493,7 @@ impl<I: ConnId> Endpoint<I> {
                 let connecting = match self.quic_endpoint.connect_with(
                     self.config.client.clone(),
                     node_addr,
-                    CERT_SERVER_NAME,
+                    SERVER_NAME,
                 ) {
                     Ok(conn) => Ok(conn),
                     Err(error) => {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -24,7 +24,13 @@ use super::{
     },
 };
 use bytes::Bytes;
-use std::net::SocketAddr;
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 use tokio::sync::broadcast::{self, Sender};
 use tokio::sync::mpsc::{self, Receiver as MpscReceiver, Sender as MpscSender};
 use tokio::time::{timeout, Duration};
@@ -80,6 +86,9 @@ pub struct Endpoint<I: ConnId> {
     termination_tx: Sender<()>,
     connection_pool: ConnectionPool<I>,
     connection_deduplicator: ConnectionDeduplicator,
+
+    // counts fully opened connections, excluding incoming and connections dropped by connect_to_any
+    opened_connection_count: Arc<AtomicUsize>,
 }
 
 impl<I: ConnId> std::fmt::Debug for Endpoint<I> {
@@ -232,6 +241,7 @@ impl<I: ConnId> Endpoint<I> {
             termination_tx: channels.termination.0.clone(),
             connection_pool: ConnectionPool::new(),
             connection_deduplicator: ConnectionDeduplicator::new(),
+            opened_connection_count: Arc::new(AtomicUsize::new(0)),
         };
 
         Ok((endpoint, quic_incoming, channels))
@@ -245,6 +255,16 @@ impl<I: ConnId> Endpoint<I> {
     /// Get the public address of the endpoint.
     pub fn public_addr(&self) -> SocketAddr {
         self.public_addr.unwrap_or(self.local_addr)
+    }
+
+    /// Get the count of opened connections.
+    ///
+    /// `Endpoint`s keep a count of connections they have fully opened and returned to callers.
+    /// Notably this excludes any incoming connections, and connections that were dropped by
+    /// [`connect_to_any`](Self::connect_to_any).
+    #[stability::unstable(feature = "opened-connection-count")]
+    pub fn opened_connection_count(&self) -> usize {
+        self.opened_connection_count.load(Ordering::Relaxed)
     }
 
     /// Removes all existing connections to a given peer
@@ -450,6 +470,9 @@ impl<I: ConnId> Endpoint<I> {
                 );
 
                 let _ = completion.complete(Ok(()));
+
+                let _ = self.opened_connection_count.fetch_add(1, Ordering::Relaxed);
+
                 Ok(connection)
             }
             Err(error) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 )]
 
 pub mod config;
+mod connection;
 mod connection_deduplicator;
 mod connection_handle;
 mod connection_pool;
@@ -58,9 +59,8 @@ mod utils;
 mod wire_msg;
 
 pub use config::{Config, ConfigError, RetryConfig};
-pub use connection_handle::{
-    ConnectionHandle as Connection, DisconnectionEvents, RecvStream, SendStream,
-};
+pub use connection::{RecvStream, SendStream};
+pub use connection_handle::{ConnectionHandle as Connection, DisconnectionEvents};
 pub use connection_pool::ConnId;
 pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
 #[cfg(feature = "igd")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@
 
 pub mod config;
 mod connection_deduplicator;
+mod connection_handle;
 mod connection_pool;
-mod connections;
 mod endpoint;
 mod error;
 #[cfg(feature = "igd")]
@@ -58,8 +58,10 @@ mod utils;
 mod wire_msg;
 
 pub use config::{Config, ConfigError, RetryConfig};
+pub use connection_handle::{
+    ConnectionHandle as Connection, DisconnectionEvents, RecvStream, SendStream,
+};
 pub use connection_pool::ConnId;
-pub use connections::{Connection, DisconnectionEvents, RecvStream, SendStream};
 pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
 #[cfg(feature = "igd")]
 pub use error::UpnpError;


### PR DESCRIPTION
- b670554 **ci: update `maidsafe/rust-version-bump-branch-creator`**

  The new version maintains the format of `Cargo.toml`, so we should be
  able to tidy that up a bit.

- 28b5658 **chore: format `Cargo.toml` and simplify `tokio` features**

  Having bumped `maidsafe/rust-version-bump-branch-creator`, the
  `Cargo.toml` format will be preserved, so we can tidy up the format.
  
  Additionally, only one of the `tokio` features were being used, apart
  from `macros` which was only needed for tests.

- 3e613f7 **feat: add a counter for opened connections to `Endpoint`**

  This is behind an `unstable-opened-connection-count` feature flag, so
  that it can be removed again in future without a breaking change. The
  intention is to use it to get a measure of the current number of
  connections that we open in downstream tests, in order to see the effect
  of removing the `ConnectionPool` and track down extraneous connections.

- b20d22b **refactor: centralise definition of certificate server name**

  This was declared both in `config` and `endpoint`, but is now exported
  from `config` and imported in `endpoint`.

- c4fe15d **refactor: store less config in `Endpoint`**

  Most of the values in `InternalConfig` are only used when constructing
  the endpoint. In fact, it turns out that only the `RetryConfig` needs to
  be remembered (since it gets passed to all opened `Connection`s).

- 7f21d58 **refactor: rename `connections` -> `connection_handle`**

  This is an internal refactor only, in preparation for replacing most of
  the connection machinery with an unpooled implementation.

- a3cb9fe **refactor: implement a non-pooled `Connection`**

  This commit adds a `connection` module, which implements a connection
  API with no dependencies on the connection pool. Most of the API has
  moved from `connection_handle`, but from now `ConnectionHandle` is
  still exported as `Connection`.
  
  When used on its own, the new `Connection` API follows the typical
  drop-based lifecycle. Once both sides of the API (`Connection` and
  `ConnectionIncoming`) are dropped, the connection will close
  automatically. However, for compability in the short term the `Endpoint`
  APIs will still put these `Connection`s in the connection pool, and poll
  for incoming messages in a background task, so for now connections will
  still remain open until error or explicit close.
