### PR TITLE
Remove disconnection events

### DIFF
--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -41,16 +41,15 @@ async fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     // create an endpoint for us to listen on and send from.
-    let (node, _incoming_conns, mut incoming_messages, _disconnections, _contact) =
-        Endpoint::<XId>::new(
-            SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
-            &[],
-            Config {
-                idle_timeout: Duration::from_secs(60 * 60).into(), // 1 hour idle timeout.
-                ..Default::default()
-            },
-        )
-        .await?;
+    let (node, _incoming_conns, mut incoming_messages, _contact) = Endpoint::<XId>::new(
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        &[],
+        Config {
+            idle_timeout: Duration::from_secs(60 * 60).into(), // 1 hour idle timeout.
+            ..Default::default()
+        },
+    )
+    .await?;
 
     // if we received args then we parse them as SocketAddr and send a "marco" msg to each peer.
     if args.len() > 1 {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -27,7 +27,11 @@ const ENDPOINT_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub(crate) struct Connection {
     inner: quinn::Connection,
-    alive_tx: Arc<watch::Sender<()>>,
+
+    // A reference to the 'alive' marker for the connection. This isn't read by `Connection`, but
+    // must be held to keep background listeners alive until both halves of the connection are
+    // dropped.
+    _alive_tx: Arc<watch::Sender<()>>,
 }
 
 impl Connection {
@@ -44,7 +48,7 @@ impl Connection {
         (
             Self {
                 inner: connection.connection,
-                alive_tx: Arc::clone(&alive_tx),
+                _alive_tx: Arc::clone(&alive_tx),
             },
             ConnectionIncoming::new(
                 endpoint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod wire_msg;
 
 pub use config::{Config, ConfigError, RetryConfig};
 pub use connection::{RecvStream, SendStream};
-pub use connection_handle::{ConnectionHandle as Connection, DisconnectionEvents};
+pub use connection_handle::ConnectionHandle as Connection;
 pub use connection_pool::ConnId;
 pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
 #[cfg(feature = "igd")]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,8 +8,7 @@
 // Software.
 
 use crate::{
-    Config, ConnId, Connection, DisconnectionEvents, Endpoint, IncomingConnections,
-    IncomingMessages, RetryConfig,
+    Config, ConnId, Connection, Endpoint, IncomingConnections, IncomingMessages, RetryConfig,
 };
 use bytes::Bytes;
 use color_eyre::eyre::Result;
@@ -41,7 +40,6 @@ pub(crate) async fn new_endpoint() -> Result<(
     Endpoint<[u8; 32]>,
     IncomingConnections<[u8; 32]>,
     IncomingMessages<[u8; 32]>,
-    DisconnectionEvents,
     Option<Connection<[u8; 32]>>,
 )> {
     Ok(Endpoint::new(


### PR DESCRIPTION
- d36b9b6 **fix: fix an unread field lint on nightly**

  The latest Rust nightlies include
  https://github.com/rust-lang/rust/pull/85200, which treats field reads
  generated by `Clone` and `Debug` impls as 'trivial', thereby not
  counting towards the identification of live code. This would commonly
  fire for fields that exist purely to keep some resource alive, as is the
  case with `Connection::alive_tx`.

- 4c06cfc **refactor: move more `ConnectionHandle` methods into `Connection`**

  This will reduce the diff when the time comes to kill
  `ConnectionHandle`.

- 9dde24b **refactor!: remove `DisconnectionEvents`**

  This removes the `DisconnectionEvents` API, and all the plumbing that
  makes it work. This is part of the move to a fully connection-oriented
  API. In that case, callers would always be working with a handle to a
  connection, and so will see if disconnections occur.
  
  BREAKING CHANGE: `DisconnectionEvents` has been removed, and is no
  longer returned from `Endpoint::new` or `Endpoint::new_client`.
