### PR TITLE
Connection incoming messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,11 @@ mod wire_msg;
 
 pub use config::{Config, ConfigError, RetryConfig};
 pub use connection::{RecvStream, SendStream};
-pub use connection_handle::ConnectionHandle as Connection;
+pub use connection_handle::{
+    ConnectionHandle as Connection, ConnectionIncomingHandle as ConnectionIncoming,
+};
 pub use connection_pool::ConnId;
-pub use endpoint::{Endpoint, IncomingConnections, IncomingMessages};
+pub use endpoint::{Endpoint, IncomingConnections};
 #[cfg(feature = "igd")]
 pub use error::UpnpError;
 pub use error::{

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -17,14 +17,14 @@ use tracing_test::traced_test;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn successful_connection() -> Result<()> {
-    let (peer1, mut peer1_incoming_connections, _, _) = new_endpoint().await?;
+    let (peer1, mut peer1_incoming_connections, _) = new_endpoint().await?;
     let peer1_addr = peer1.public_addr();
 
-    let (peer2, _, _, _) = new_endpoint().await?;
+    let (peer2, _, _) = new_endpoint().await?;
     peer2.connect_to(&peer1_addr).await.map(drop)?;
     let peer2_addr = peer2.public_addr();
 
-    if let Ok(Some(connection)) = peer1_incoming_connections.next().timeout().await {
+    if let Ok(Some((connection, _))) = peer1_incoming_connections.next().timeout().await {
         assert_eq!(connection.remote_address(), peer2_addr);
     } else {
         bail!("No incoming connection");
@@ -38,29 +38,30 @@ async fn successful_connection() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn single_message() -> Result<()> {
-    let (peer1, mut peer1_incoming_connections, mut peer1_incoming_messages, _) =
-        new_endpoint().await?;
+    let (peer1, mut peer1_incoming_connections, _) = new_endpoint().await?;
     let peer1_addr = peer1.public_addr();
 
-    let (peer2, _, _, _) = new_endpoint().await?;
+    let (peer2, _, _) = new_endpoint().await?;
     let peer2_addr = peer2.public_addr();
 
     // Peer 2 connects and sends a message
-    let connection = peer2.connect_to(&peer1_addr).await?;
+    let (connection, _) = peer2.connect_to(&peer1_addr).await?;
     let msg_from_peer2 = random_msg(1024);
     connection.send(msg_from_peer2.clone()).await?;
 
     // Peer 1 gets an incoming connection
-    if let Ok(Some(connection)) = peer1_incoming_connections.next().timeout().await {
+    let mut peer1_incoming_messages = if let Ok(Some((connection, incoming))) =
+        peer1_incoming_connections.next().timeout().await
+    {
         assert_eq!(connection.remote_address(), peer2_addr);
+        incoming
     } else {
         bail!("No incoming connection");
-    }
+    };
 
     // Peer 2 gets an incoming message
-    if let Ok(Some((connection, message))) = peer1_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), peer2_addr);
-        assert_eq!(message, msg_from_peer2);
+    if let Ok(message) = peer1_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg_from_peer2));
     } else {
         bail!("No incoming message");
     }
@@ -73,47 +74,47 @@ async fn single_message() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reuse_outgoing_connection() -> Result<()> {
-    let (alice, _, _, _) = new_endpoint().await?;
+    let (alice, _, _) = new_endpoint().await?;
     let alice_addr = alice.public_addr();
 
-    let (bob, mut bob_incoming_connections, mut bob_incoming_messages, _) = new_endpoint().await?;
+    let (bob, mut bob_incoming_connections, _) = new_endpoint().await?;
     let bob_addr = bob.public_addr();
 
     // Connect for the first time and send a message.
-    let a_to_b = alice.connect_to(&bob_addr).await?;
+    let (a_to_b, _) = alice.connect_to(&bob_addr).await?;
     let msg0 = random_msg(1024);
     a_to_b.send(msg0.clone()).await?;
 
     // Bob should recieve an incoming connection and message
-    if let Ok(Some(connection)) = bob_incoming_connections.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-    } else {
-        bail!("No incoming connection");
-    }
+    let mut bob_incoming_messages =
+        if let Ok(Some((connection, incoming))) = bob_incoming_connections.next().timeout().await {
+            assert_eq!(connection.remote_address(), alice_addr);
+            incoming
+        } else {
+            bail!("No incoming connection");
+        };
 
-    if let Ok(Some((connection, message))) = bob_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-        assert_eq!(message, msg0);
+    if let Ok(message) = bob_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg0));
     } else {
         bail!("No incoming message");
     }
 
     // Try connecting again and send a message
-    let a_to_b = alice.connect_to(&bob_addr).await?;
+    let (a_to_b, _) = alice.connect_to(&bob_addr).await?;
     let msg1 = random_msg(1024);
     a_to_b.send(msg1.clone()).await?;
 
     // Bob *should not* get an incoming connection since there is already a connection established
-    if let Ok(Some(connection)) = bob_incoming_connections.next().timeout().await {
+    if let Ok(Some((connection, _))) = bob_incoming_connections.next().timeout().await {
         bail!(
             "Unexpected incoming connection from {}",
             connection.remote_address()
         );
     }
 
-    if let Ok(Some((connection, message))) = bob_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-        assert_eq!(message, msg1);
+    if let Ok(message) = bob_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg1));
     } else {
         bail!("No incoming message");
     }
@@ -126,49 +127,54 @@ async fn reuse_outgoing_connection() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reuse_incoming_connection() -> Result<()> {
-    let (alice, mut alice_incoming_connections, mut alice_incoming_messages, _) =
-        new_endpoint().await?;
+    let (alice, mut alice_incoming_connections, _) = new_endpoint().await?;
     let alice_addr = alice.public_addr();
 
-    let (bob, mut bob_incoming_connections, mut bob_incoming_messages, _) = new_endpoint().await?;
+    let (bob, mut bob_incoming_connections, _) = new_endpoint().await?;
     let bob_addr = bob.public_addr();
 
     // Connect for the first time and send a message.
-    let a_to_b = alice.connect_to(&bob_addr).await?;
+    let (a_to_b, alice_incoming_messages) = alice.connect_to(&bob_addr).await?;
+    let mut alice_incoming_messages = alice_incoming_messages
+        .ok_or_else(|| eyre!("expected ConnectionIncoming in first connection"))?;
     let msg0 = random_msg(1024);
     a_to_b.send(msg0.clone()).await?;
 
     // Bob should recieve an incoming connection and message
-    if let Ok(Some(connection)) = bob_incoming_connections.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-    } else {
-        bail!("No incoming connection");
-    }
+    let mut bob_incoming_messages =
+        if let Ok(Some((connection, incoming))) = bob_incoming_connections.next().timeout().await {
+            assert_eq!(connection.remote_address(), alice_addr);
+            incoming
+        } else {
+            bail!("No incoming connection");
+        };
 
-    if let Ok(Some((connection, message))) = bob_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-        assert_eq!(message, msg0);
+    if let Ok(message) = bob_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg0));
     } else {
         bail!("No incoming message");
     }
 
     // Bob tries to connect to alice and sends a message
-    let b_to_a = bob.connect_to(&alice_addr).await?;
+    let (b_to_a, maybe_incoming) = bob.connect_to(&alice_addr).await?;
+    assert!(
+        maybe_incoming.is_none(),
+        "expected no ConnectionIncoming due to reuse"
+    );
     let msg1 = random_msg(1024);
     b_to_a.send(msg1.clone()).await?;
 
     // Alice *will not* get an incoming connection since there is already a connection established
     // However, Alice will still get the incoming message
-    if let Ok(Some(connection)) = alice_incoming_connections.next().timeout().await {
+    if let Ok(Some((connection, _))) = alice_incoming_connections.next().timeout().await {
         bail!(
             "Unexpected incoming connection from {}",
             connection.remote_address()
         );
     }
 
-    if let Ok(Some((connection, message))) = alice_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), bob_addr);
-        assert_eq!(message, msg1);
+    if let Ok(message) = alice_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg1));
     } else {
         bail!("No incoming message");
     }
@@ -185,27 +191,31 @@ async fn simultaneous_incoming_and_outgoing_connections() -> Result<()> {
     // others connection first), two separate connections are created. This test verifies that
     // everything still works correctly even in this case.
 
-    let (alice, mut alice_incoming_connections, mut alice_incoming_messages, _) =
-        new_endpoint().await?;
+    let (alice, mut alice_incoming_connections, _) = new_endpoint().await?;
     let alice_addr = alice.public_addr();
 
-    let (bob, mut bob_incoming_connections, mut bob_incoming_messages, _) = new_endpoint().await?;
+    let (bob, mut bob_incoming_connections, _) = new_endpoint().await?;
     let bob_addr = bob.public_addr();
 
-    let (a_to_b, b_to_a) =
+    let ((a_to_b, _), (b_to_a, _)) =
         future::try_join(alice.connect_to(&bob_addr), bob.connect_to(&alice_addr)).await?;
 
-    if let Ok(Some(connection)) = alice_incoming_connections.next().timeout().await {
+    let mut alice_incoming_messages = if let Ok(Some((connection, incoming))) =
+        alice_incoming_connections.next().timeout().await
+    {
         assert_eq!(connection.remote_address(), bob_addr);
+        incoming
     } else {
         bail!("No incoming connection from Bob");
-    }
+    };
 
-    if let Ok(Some(connection)) = bob_incoming_connections.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-    } else {
-        bail!("No incoming connectino from Alice");
-    }
+    let mut bob_incoming_messages =
+        if let Ok(Some((connection, incoming))) = bob_incoming_connections.next().timeout().await {
+            assert_eq!(connection.remote_address(), alice_addr);
+            incoming
+        } else {
+            bail!("No incoming connectino from Alice");
+        };
 
     let msg0 = random_msg(1024);
     a_to_b.send(msg0.clone()).await?;
@@ -213,16 +223,14 @@ async fn simultaneous_incoming_and_outgoing_connections() -> Result<()> {
     let msg1 = random_msg(1024);
     b_to_a.send(msg1.clone()).await?;
 
-    if let Ok(Some((connection, message))) = alice_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), bob_addr);
-        assert_eq!(message, msg1);
+    if let Ok(message) = alice_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg1));
     } else {
         bail!("Missing incoming message");
     }
 
-    if let Ok(Some((connection, message))) = bob_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-        assert_eq!(message, msg0);
+    if let Ok(message) = bob_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg0));
     } else {
         bail!("Missing incoming message");
     }
@@ -231,20 +239,22 @@ async fn simultaneous_incoming_and_outgoing_connections() -> Result<()> {
     bob.disconnect_from(&alice_addr).await;
 
     // Bob connects to Alice again. This opens a new connection.
-    let b_to_a = bob.connect_to(&alice_addr).await?;
+    let (b_to_a, _) = bob.connect_to(&alice_addr).await?;
 
-    if let Ok(Some(connection)) = alice_incoming_connections.next().timeout().await {
+    let mut alice_incoming_messages = if let Ok(Some((connection, incoming))) =
+        alice_incoming_connections.next().timeout().await
+    {
         assert_eq!(connection.remote_address(), bob_addr);
+        incoming
     } else {
         bail!("Missing incoming connection");
-    }
+    };
 
     let msg2 = random_msg(1024);
     b_to_a.send(msg2.clone()).await?;
 
-    if let Ok(Some((connection, message))) = alice_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), bob_addr);
-        assert_eq!(message, msg2);
+    if let Ok(message) = alice_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg2));
     }
 
     assert_eq!(alice.opened_connection_count(), 1);
@@ -255,25 +265,30 @@ async fn simultaneous_incoming_and_outgoing_connections() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_concurrent_connects_to_the_same_peer() -> Result<()> {
-    let (alice, mut alice_incoming_connections, mut alice_incoming_messages, _) =
-        new_endpoint().await?;
+    let (alice, mut alice_incoming_connections, _) = new_endpoint().await?;
     let alice_addr = alice.public_addr();
 
-    let (bob, mut bob_incoming_connections, mut bob_incoming_messages, _) = new_endpoint().await?;
+    let (bob, mut bob_incoming_connections, _) = new_endpoint().await?;
     let bob_addr = bob.public_addr();
 
     // Try to establish two connections to the same peer at the same time.
-    let (b_to_a, _) =
+    let ((b_to_a, bob_incoming_messages_1), (_, bob_incoming_messages_2)) =
         future::try_join(bob.connect_to(&alice_addr), bob.connect_to(&alice_addr)).await?;
+    let mut bob_incoming_messages = bob_incoming_messages_1
+        .or(bob_incoming_messages_2)
+        .ok_or_else(|| eyre!("expected ConnectionIncoming in first connection"))?;
 
     // Alice get only one incoming connection
-    if let Ok(Some(connection)) = alice_incoming_connections.next().timeout().await {
+    let mut alice_incoming_messages = if let Ok(Some((connection, incoming))) =
+        alice_incoming_connections.next().timeout().await
+    {
         assert_eq!(connection.remote_address(), bob_addr);
+        incoming
     } else {
         bail!("Missing incoming connection");
-    }
+    };
 
-    if let Ok(Some(connection)) = alice_incoming_connections.next().timeout().await {
+    if let Ok(Some((connection, _))) = alice_incoming_connections.next().timeout().await {
         bail!(
             "Unexpected incoming connection from {}",
             connection.remote_address()
@@ -285,6 +300,7 @@ async fn multiple_concurrent_connects_to_the_same_peer() -> Result<()> {
     alice
         .connect_to(&bob_addr)
         .await?
+        .0
         .send(msg0.clone())
         .await?;
 
@@ -297,16 +313,14 @@ async fn multiple_concurrent_connects_to_the_same_peer() -> Result<()> {
     }
 
     // Both messages are received  at the other end
-    if let Ok(Some((connection, message))) = alice_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), bob_addr);
-        assert_eq!(message, msg1);
+    if let Ok(message) = alice_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg1));
     } else {
         bail!("No message received from Bob");
     }
 
-    if let Ok(Some((connection, message))) = bob_incoming_messages.next().timeout().await {
-        assert_eq!(connection.remote_address(), alice_addr);
-        assert_eq!(message, msg0);
+    if let Ok(message) = bob_incoming_messages.next().timeout().await {
+        assert_eq!(message?, Some(msg0));
     } else {
         bail!("No message from alice");
     }
@@ -325,7 +339,7 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
     let num_messages_each: usize = 100;
     let num_messages_total: usize = 1000;
 
-    let (server_endpoint, _, mut recv_incoming_messages, _) = new_endpoint().await?;
+    let (server_endpoint, mut recv_incoming_connections, _) = new_endpoint().await?;
     let server_addr = server_endpoint.public_addr();
 
     let test_msgs: Vec<_> = (0..num_messages_each).map(|_| random_msg(1024)).collect();
@@ -339,35 +353,43 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
             let mut num_received = 0;
             let mut sending_tasks = Vec::new();
 
-            while let Some((connection, msg)) = recv_incoming_messages.next().await {
-                info!(
-                    "received from {:?} with message size {}",
-                    connection.remote_address(),
-                    msg.len()
-                );
-                assert_eq!(msg.len(), test_msgs[0].len());
+            while let Some((connection, mut recv_incoming_messages)) =
+                recv_incoming_connections.next().await
+            {
+                while let Ok(Ok(Some(msg))) = recv_incoming_messages.next().timeout().await {
+                    info!(
+                        "received from {:?} with message size {}",
+                        connection.remote_address(),
+                        msg.len()
+                    );
+                    assert_eq!(msg.len(), test_msgs[0].len());
 
-                sending_tasks.push(tokio::spawn({
-                    async move {
-                        // Hash the inputs for couple times to simulate certain workload.
-                        let hash_result = hash(&msg);
-                        for _ in 0..5 {
-                            let _ = hash(&msg);
+                    sending_tasks.push(tokio::spawn({
+                        let connection = connection.clone();
+                        async move {
+                            // Hash the inputs for couple times to simulate certain workload.
+                            let hash_result = hash(&msg);
+                            for _ in 0..5 {
+                                let _ = hash(&msg);
+                            }
+                            // Send the hash result back.
+                            connection.send(hash_result.to_vec().into()).await?;
+
+                            Ok::<_, Report>(())
                         }
-                        // Send the hash result back.
-                        connection.send(hash_result.to_vec().into()).await?;
+                    }));
 
-                        Ok::<_, Report>(())
-                    }
-                }));
-
-                num_received += 1;
+                    num_received += 1;
+                }
                 if num_received >= num_messages_total {
                     break;
                 }
             }
 
-            let _ = future::try_join_all(sending_tasks).await?;
+            future::try_join_all(sending_tasks)
+                .await?
+                .into_iter()
+                .collect::<Result<_>>()?;
 
             Ok(())
         }
@@ -377,11 +399,14 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
     for id in 0..num_senders {
         let messages = sending_msgs.clone();
         tasks.push(tokio::spawn({
-            let (send_endpoint, _, mut recv_incoming_messages, _) = new_endpoint().await?;
+            let (send_endpoint, _, _) = new_endpoint().await?;
 
             async move {
                 let mut hash_results = BTreeSet::new();
-                let connection = send_endpoint.connect_to(&server_addr).await?;
+                let (connection, recv_incoming_messages) =
+                    send_endpoint.connect_to(&server_addr).await?;
+                let mut recv_incoming_messages = recv_incoming_messages
+                    .ok_or_else(|| eyre!("expected ConnectionIncoming in first connection"))?;
                 for (index, message) in messages.iter().enumerate().take(num_messages_each) {
                     let _ = hash_results.insert(hash(message));
                     info!("sender #{} sending message #{}", id, index);
@@ -393,7 +418,7 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
                     id
                 );
 
-                while let Some((connection, msg)) = recv_incoming_messages.next().await {
+                while let Ok(Ok(Some(msg))) = recv_incoming_messages.next().timeout().await {
                     info!(
                         "#{} received from server {:?} with message size {}",
                         id,
@@ -417,7 +442,10 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
         }));
     }
 
-    let _ = future::try_join_all(tasks).await?;
+    future::try_join_all(tasks)
+        .await?
+        .into_iter()
+        .collect::<Result<_>>()?;
 
     assert_eq!(server_endpoint.opened_connection_count(), 0);
 
@@ -431,7 +459,7 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
     let num_messages_each: usize = 100;
     let num_messages_total: usize = num_senders * num_messages_each;
 
-    let (server_endpoint, _, mut recv_incoming_messages, _) = new_endpoint().await?;
+    let (server_endpoint, mut recv_incoming_connections, _) = new_endpoint().await?;
     let server_addr = server_endpoint.public_addr();
 
     let test_msgs: Vec<_> = (0..num_messages_each)
@@ -447,28 +475,33 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
             let mut num_received = 0;
             assert!(!logs_contain("error"));
 
-            while let Some((connection, msg)) = recv_incoming_messages.next().await {
-                info!(
-                    "received from {:?} with message size {}",
-                    connection.remote_address(),
-                    msg.len()
-                );
-                assert!(!logs_contain("error"));
+            while let Some((connection, mut recv_incoming_messages)) =
+                recv_incoming_connections.next().await
+            {
+                while let Ok(Ok(Some(msg))) = recv_incoming_messages.next().timeout().await {
+                    info!(
+                        "received from {:?} with message size {}",
+                        connection.remote_address(),
+                        msg.len()
+                    );
+                    assert!(!logs_contain("error"));
 
-                assert_eq!(msg.len(), test_msgs[0].len());
+                    assert_eq!(msg.len(), test_msgs[0].len());
 
-                let hash_result = hash(&msg);
-                for _ in 0..5 {
-                    let _ = hash(&msg);
+                    let hash_result = hash(&msg);
+                    for _ in 0..5 {
+                        let _ = hash(&msg);
+                    }
+
+                    // Send the hash result back.
+                    connection.send(hash_result.to_vec().into()).await?;
+
+                    assert!(!logs_contain("error"));
+
+                    num_received += 1;
+                    // println!("Server received count: {}", num_received);
                 }
 
-                // Send the hash result back.
-                connection.send(hash_result.to_vec().into()).await?;
-
-                assert!(!logs_contain("error"));
-
-                num_received += 1;
-                // println!("Server received count: {}", num_received);
                 if num_received >= num_messages_total {
                     break;
                 }
@@ -486,12 +519,15 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
         assert!(!logs_contain("error"));
 
         tasks.push(tokio::spawn({
-            let (send_endpoint, _, mut recv_incoming_messages, _) = new_endpoint().await?;
+            let (send_endpoint, _, _) = new_endpoint().await?;
 
             async move {
                 let mut hash_results = BTreeSet::new();
 
-                let connection = send_endpoint.connect_to(&server_addr).await?;
+                let (connection, recv_incoming_messages) =
+                    send_endpoint.connect_to(&server_addr).await?;
+                let mut recv_incoming_messages = recv_incoming_messages
+                    .ok_or_else(|| eyre!("expected ConnectionIncoming in first connection"))?;
                 for (index, message) in messages.iter().enumerate().take(num_messages_each) {
                     let _ = hash_results.insert(hash(message));
 
@@ -504,14 +540,14 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
                     id
                 );
 
-                while let Some((connection, msg)) = recv_incoming_messages.next().await {
+                while let Some(msg) = recv_incoming_messages.next().await? {
                     assert!(!logs_contain("error"));
 
                     info!(
                         "sender #{} received from server {:?} with message size {:?}",
                         id,
                         connection.remote_address(),
-                        msg
+                        msg.len()
                     );
 
                     info!("Hash len before: {:?}", hash_results.len());
@@ -549,8 +585,8 @@ async fn many_messages() -> Result<()> {
 
     let num_messages: usize = 10_000;
 
-    let (send_endpoint, _, _, _) = new_endpoint().await?;
-    let (recv_endpoint, _, mut recv_incoming_messages, _) = new_endpoint().await?;
+    let (send_endpoint, _, _) = new_endpoint().await?;
+    let (recv_endpoint, mut recv_incoming_connections, _) = new_endpoint().await?;
 
     let send_addr = send_endpoint.public_addr();
     let recv_addr = recv_endpoint.public_addr();
@@ -566,7 +602,7 @@ async fn many_messages() -> Result<()> {
             async move {
                 info!("sending {}", id);
                 let msg = id.to_le_bytes().to_vec().into();
-                endpoint.connect_to(&recv_addr).await?.send(msg).await?;
+                endpoint.connect_to(&recv_addr).await?.0.send(msg).await?;
                 info!("sent {}", id);
 
                 Ok::<_, Report>(())
@@ -579,12 +615,17 @@ async fn many_messages() -> Result<()> {
         async move {
             let mut num_received = 0;
 
-            while let Some((connection, msg)) = recv_incoming_messages.next().await {
-                let id = usize::from_le_bytes(msg[..].try_into().unwrap());
+            while let Some((connection, mut recv_incoming_messages)) =
+                recv_incoming_connections.next().await
+            {
                 assert_eq!(connection.remote_address(), send_addr);
-                info!("received {}", id);
 
-                num_received += 1;
+                while let Ok(Ok(Some(msg))) = recv_incoming_messages.next().timeout().await {
+                    let id = usize::from_le_bytes(msg[..].try_into().unwrap());
+                    info!("received {}", id);
+
+                    num_received += 1;
+                }
 
                 if num_received >= num_messages {
                     break;
@@ -608,13 +649,13 @@ async fn many_messages() -> Result<()> {
 // bootstrap contacts later.
 #[tokio::test(flavor = "multi_thread")]
 async fn connection_attempts_to_bootstrap_contacts_should_succeed() -> Result<()> {
-    let (ep1, _, _, _) = new_endpoint().await?;
-    let (ep2, _, _, _) = new_endpoint().await?;
-    let (ep3, _, _, _) = new_endpoint().await?;
+    let (ep1, _, _) = new_endpoint().await?;
+    let (ep2, _, _) = new_endpoint().await?;
+    let (ep3, _, _) = new_endpoint().await?;
 
     let contacts = vec![ep1.public_addr(), ep2.public_addr(), ep3.public_addr()];
 
-    let (ep, _, _, bootstrapped_peer) = Endpoint::<[u8; 32]>::new(
+    let (ep, _, bootstrapped_peer) = Endpoint::<[u8; 32]>::new(
         local_addr(),
         &contacts,
         Config {
@@ -626,7 +667,7 @@ async fn connection_attempts_to_bootstrap_contacts_should_succeed() -> Result<()
         },
     )
     .await?;
-    let bootstrapped_peer =
+    let (bootstrapped_peer, _) =
         bootstrapped_peer.ok_or_else(|| eyre!("Failed to connecto to any contact"))?;
 
     for peer in contacts {
@@ -645,8 +686,8 @@ async fn connection_attempts_to_bootstrap_contacts_should_succeed() -> Result<()
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reachability() -> Result<()> {
-    let (ep1, _, _, _) = new_endpoint().await?;
-    let (ep2, _, _, _) = new_endpoint().await?;
+    let (ep1, _, _) = new_endpoint().await?;
+    let (ep2, _, _) = new_endpoint().await?;
 
     if let Ok(()) = ep1.is_reachable(&"127.0.0.1:12345".parse()?).await {
         bail!("Unexpected success");
@@ -665,8 +706,8 @@ async fn reachability() -> Result<()> {
 async fn client() -> Result<()> {
     use crate::{Config, Endpoint};
 
-    let (server, _, mut server_messages, _) = new_endpoint().await?;
-    let (client, mut client_messages) = Endpoint::<[u8; 32]>::new_client(
+    let (server, mut server_connections, _) = new_endpoint().await?;
+    let client = Endpoint::<[u8; 32]>::new_client(
         local_addr(),
         Config {
             retry_config: RetryConfig {
@@ -677,31 +718,37 @@ async fn client() -> Result<()> {
         },
     )?;
 
-    client
-        .connect_to(&server.public_addr())
-        .await?
-        .send(b"hello"[..].into())
-        .await?;
+    let (client_to_server, client_messages) = client.connect_to(&server.public_addr()).await?;
+    let mut client_messages =
+        client_messages.ok_or_else(|| eyre!("expected ConnectionIncoming in first connection"))?;
+    client_to_server.send(b"hello"[..].into()).await?;
 
-    let (client_to_server, message) = server_messages
+    let (server_to_client, mut server_messages) = server_connections
+        .next()
+        .await
+        .ok_or_else(|| eyre!("did not receive expected connection"))?;
+    assert_eq!(server_to_client.remote_address(), client.public_addr());
+
+    let message = server_messages
         .next()
         .timeout()
         .await
         .ok()
+        .map(Result::transpose)
         .flatten()
-        .ok_or_else(|| eyre!("Did not receive expected message"))?;
-    assert_eq!(client_to_server.remote_address(), client.public_addr());
+        .ok_or_else(|| eyre!("Did not receive expected message"))??;
     assert_eq!(&message[..], b"hello");
 
-    client_to_server.send(b"world"[..].into()).await?;
-    let (server_to_client, message) = client_messages
+    server_to_client.send(b"world"[..].into()).await?;
+
+    let message = client_messages
         .next()
         .timeout()
         .await
         .ok()
+        .map(Result::transpose)
         .flatten()
-        .ok_or_else(|| eyre!("Did not receive expected message"))?;
-    assert_eq!(server_to_client.remote_address(), server.public_addr());
+        .ok_or_else(|| eyre!("Did not receive expected message"))??;
     assert_eq!(&message[..], b"world");
 
     server.disconnect_from(&client.public_addr()).await;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use crate::{
-    Config, ConnId, Connection, Endpoint, IncomingConnections, IncomingMessages, RetryConfig,
+    Config, ConnId, Connection, ConnectionIncoming, Endpoint, IncomingConnections, RetryConfig,
 };
 use bytes::Bytes;
 use color_eyre::eyre::Result;
@@ -39,8 +39,7 @@ impl ConnId for [u8; 32] {
 pub(crate) async fn new_endpoint() -> Result<(
     Endpoint<[u8; 32]>,
     IncomingConnections<[u8; 32]>,
-    IncomingMessages<[u8; 32]>,
-    Option<Connection<[u8; 32]>>,
+    Option<(Connection<[u8; 32]>, Option<ConnectionIncoming<[u8; 32]>>)>,
 )> {
     Ok(Endpoint::new(
         local_addr(),


### PR DESCRIPTION
- 948cb8f **refactor: add a `Timeout` helper trait to tests**

  This makes it much more concise to add timeouts to futures, which is
  good because there should be a lot more of them...

- 18786cd **refactor: add additional timeouts to tests**

  This covers all the `stream.next()` futures, which would otherwise await
  forever. This ensures we get a more useful error in these cases, rather
  than hung tests.

- 75dd034 **fix: don't retry sending on connection loss**

  If the connection is lost, there's not point in trying again to send
  using the same connection. This would have to be handled by the caller,
  who can choose how to respond (e.g. reconnect and try again, or bail).

- 908b979 **refactor!: remove `IncomingMessages`**

  This is part of the move to a fully connection-oriented API. The
  per-connection `ConnectionIncoming` streams must be used instead.
  
  Since `ConnectionIncoming` cannot be cloned (since the inner
  `mpsc::Receiver` cannot be cloned), methods that use the connection pool
  return an `Option<ConnectionIncoming>`. This also reveals one of the
  inconsistencies with the connection pool, in that incoming connections
  always come with a `ConnectionIncoming`, since they replace anything
  already in the pool.
  
  As with `Connection`, it's currently a connection-pool-specific wrapper
  that's returned (`ConnectionIncomingHandle`). This is necessary to
  ensure that lost connections are removed from the pool. These wrappers
  will go away when the connection pool is removed, and the API should
  remain unchanged.
  
  BREAKING CHANGE: `IncomingMessages` has been removed, and is no longer
  returned by `Endpoint::new` or `Endpoint::new_client`.
