### PR TITLE
Disable keep-alives by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,14 +18,6 @@ use std::{future::Future, net::IpAddr, sync::Arc, time::Duration};
 /// see no conversation between them.
 pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Default for [`Config::keep_alive_interval`] (20 seconds).
-pub const DEFAULT_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(20);
-
-// serde needs a function when specifying a path for `default`
-fn default_keep_alive_interval() -> Option<Duration> {
-    Some(DEFAULT_KEEP_ALIVE_INTERVAL)
-}
-
 /// Default for [`Config::upnp_lease_duration`] (2 minutes).
 pub const DEFAULT_UPNP_LEASE_DURATION: Duration = Duration::from_secs(120);
 
@@ -97,7 +89,7 @@ pub struct CertificateGenerationError(
 );
 
 /// QuicP2p configurations
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Config {
     /// Specify if port forwarding via UPnP should be done or not. This can be set to false if the network
     /// is run locally on the network loopback or on a local area network.
@@ -127,8 +119,8 @@ pub struct Config {
     ///
     /// Keep-alives prevent otherwise idle connections from timing out.
     ///
-    /// If unspecified, this will default to [`DEFAULT_KEEP_ALIVE_INTERVAL`].
-    #[serde(default = "default_keep_alive_interval")]
+    /// If unspecified, this will default to `None`, disabling keep-alives.
+    #[serde(default)]
     pub keep_alive_interval: Option<Duration>,
 
     /// How long UPnP port mappings will last.
@@ -144,21 +136,6 @@ pub struct Config {
     /// Determines the retry behaviour of requests, by setting the back off strategy used.
     #[serde(default)]
     pub retry_config: RetryConfig,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "igd")]
-            forward_port: Default::default(),
-            external_port: Default::default(),
-            external_ip: Default::default(),
-            idle_timeout: Default::default(),
-            keep_alive_interval: default_keep_alive_interval(),
-            upnp_lease_duration: Default::default(),
-            retry_config: Default::default(),
-        }
-    }
 }
 
 /// Retry configurations for establishing connections and sending messages.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -64,6 +64,15 @@ impl Connection {
         )
     }
 
+    /// A stable identifier for the connection.
+    ///
+    /// This ID will not change for the lifetime of the connection. Note that the connection ID will
+    /// be different at each peer, so this is most useful for tracing connection activity within a
+    /// single peer.
+    pub fn id(&self) -> usize {
+        self.inner.stable_id()
+    }
+
     /// The address of the remote peer.
     pub fn remote_address(&self) -> SocketAddr {
         self.inner.remote_address()

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -822,6 +822,6 @@ trait Timeout: Sized {
 
 impl<F: std::future::Future> Timeout for F {
     fn timeout(self) -> tokio::time::Timeout<Self> {
-        tokio::time::timeout(Duration::from_secs(2), self)
+        tokio::time::timeout(Duration::from_secs(10), self)
     }
 }

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -12,6 +12,7 @@ use crate::{
     utils,
 };
 use bytes::Bytes;
+use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::{fmt, net::SocketAddr};
@@ -39,9 +40,20 @@ impl WireMsg {
     ) -> Result<Option<Self>, RecvError> {
         let mut header_bytes = [0; MSG_HEADER_LEN];
 
-        match recv.read(&mut header_bytes).await? {
-            None => return Ok(None),
-            Some(len) => {
+        match recv.read(&mut header_bytes).err_into().await {
+            Err(RecvError::ConnectionLost(error)) if error.is_benign() => {
+                // We ignore 'benign' connection loss for the initial read, this follows from the
+                // understanding that quinn would always yield any successfully read bytes, so we
+                // would move further into the function, which will always propagated encountered
+                // errors.
+                return Ok(None);
+            }
+            Err(error) => {
+                // Any other error would indicate a real issue, so return it
+                return Err(error);
+            }
+            Ok(None) => return Ok(None),
+            Ok(Some(len)) => {
                 if len < MSG_HEADER_LEN {
                     recv.read_exact(&mut header_bytes[len..]).await?;
                 }


### PR DESCRIPTION
- 10fa647 **fix: more carefully handle 'benign' connection loss**

  This changes the behaviour of the `ConnectionIncoming` pseudo-stream to
  signal end-of-stream when the connection closes for a 'benign' reason,
  rather than returning an error. This makes it much easier to implement
  message polling for callers, without them having to apply their own
  filtering.
  
  Since we're doing this detection in a couple of places, it made sense to
  move the check into `ConnectionError` itself.

- e511c59 **test: rewrite large message test with more concurrency**

  The old `IncomingMessages` stream would multiplex over all incoming
  connections. When we removed this, we inadvertently made this test
  process each connection fully, and sequentially, which leads to hitting
  various timeouts (both the timeouts in the test, and idle
  timeouts on the connection) more often.
  
  Concurrency has been restored with
  `TryStreamExt::try_for_each_concurrent`, which is used to process all
  incoming connections concurrently once again.

- f520fcf **refactor!: disable keep-alives by default**

  This changes the `keep_alive_interval` set for `Config::default()` to
  `None`, disabling keep-alives. This is thought to be a more sane default
  for a library, since keep-alives may otherwise cause connections to stay
  open forever, leaking resources. It remains easy to opt-in to
  keep-alives by simply setting `Some(duration)`.
  
  BREAKING CHANGE: The `qp2p::config::DEFAULT_KEEP_ALIVE_INTERVAL`
  constant has been removed, and the default value for
  `keep_alive_interval` set for `Config::default()` is now `None`, meaning
  keep-alives are disabled by default.

- 8186416 **feat: add `Connection::id` to get a stable ID for a connection**

  This just proxies the underlying `quinn::Connection::stable_id`. This is
  actually implemented in `quinn` as the address in memory of the
  underlying shared connection reference, so although it is stable for the
  lifetime of a connection it is not comparable across peers. It's still
  useful for tracking connections within a single peer.

- 79986c8 **chore: add more logging when handling echo/verify requests**

  Since these processes are transparent for callers, its easy to forget
  that they exist at all. This can lead to some confusion when trying to
  trace connection activity, since they might look spurious. Some
  additional logging here should help to clarify what's the craic.

- fe7450a **test: increase timeout for some tests**

  We want tests to fail, rather than hanging forever, in situation where
  we expect some incoming connection/message. Sadly, setting this timeout
  is a bit arbitrary, and depending on the performance of the system
  running the tests they could fire spuriously. That seems to be what
  we're seeing in CI, so we're bumping the timeout to compensate.
  
  Note that this will make some tests take longer, since the timeout is
  also used to check that something we don't expect to happen, doesn't
  happen.
