### PR TITLE
Remove connection counting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maidsafe/qp2p"
 version = "0.27.0"
 authors = [ "MaidSafe Developers <dev@maidsafe.net>" ]
 keywords = [ "quic" ]
-edition = "2018"
+edition = "2021"
 
 [[example]]
 name = "p2p_node"
@@ -34,7 +34,6 @@ rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
 serde = { version = "1.0.117", features = ["derive"] }
 stability = "0.1.0"
 thiserror = "1.0.23"
-tiny-keccak = "2.0.2"
 tokio = { version = "1.2.0", features = ["sync"] }
 tracing = "~0.1.26"
 webpki = "~0.21.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,9 @@ edition = "2021"
 
 [[example]]
 name = "p2p_node"
-required-features = ["unstable-opened-connection-count"]
 
 [features]
 default = [ "igd" ]
-
-# `unstable-` features may be removed at any time without a breaking change release
-unstable-opened-connection-count = []
 
 [dependencies]
 backoff = { version = "0.3.0", features = ["tokio"] }
@@ -32,7 +28,6 @@ quinn-proto = "0.7.3"
 rcgen = "~0.8.4"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
 serde = { version = "1.0.117", features = ["derive"] }
-stability = "0.1.0"
 thiserror = "1.0.23"
 tokio = { version = "1.2.0", features = ["sync"] }
 tracing = "~0.1.26"

--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -56,10 +56,7 @@ async fn main() -> Result<()> {
             node.connect_to(&peer).await?.0.send(msg.clone()).await?;
         }
 
-        println!(
-            "Done sending, opened {} connections",
-            node.opened_connection_count()
-        );
+        println!("Done sending");
     }
 
     println!("\n---");

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -39,9 +39,6 @@ async fn successful_connection() -> Result<()> {
         bail!("No incoming connection");
     }
 
-    assert_eq!(peer1.opened_connection_count(), 0);
-    assert_eq!(peer2.opened_connection_count(), 1);
-
     Ok(())
 }
 
@@ -74,9 +71,6 @@ async fn single_message() -> Result<()> {
     } else {
         bail!("No incoming message");
     }
-
-    assert_eq!(peer1.opened_connection_count(), 0);
-    assert_eq!(peer2.opened_connection_count(), 1);
 
     Ok(())
 }
@@ -134,9 +128,6 @@ async fn no_reuse_outgoing_connection() -> Result<()> {
         bail!("No incoming message");
     }
 
-    assert_eq!(alice.opened_connection_count(), 2);
-    assert_eq!(bob.opened_connection_count(), 0);
-
     Ok(())
 }
 
@@ -193,9 +184,6 @@ async fn no_reuse_incoming_connection() -> Result<()> {
     } else {
         bail!("No incoming message");
     }
-
-    assert_eq!(alice.opened_connection_count(), 1);
-    assert_eq!(bob.opened_connection_count(), 1);
 
     Ok(())
 }
@@ -273,9 +261,6 @@ async fn simultaneous_incoming_and_outgoing_connections() -> Result<()> {
         assert_eq!(message?, Some(msg2));
     }
 
-    assert_eq!(alice.opened_connection_count(), 1);
-    assert_eq!(bob.opened_connection_count(), 2);
-
     Ok(())
 }
 
@@ -337,9 +322,6 @@ async fn multiple_concurrent_connects_to_the_same_peer() -> Result<()> {
     } else {
         bail!("No message from alice");
     }
-
-    assert_eq!(alice.opened_connection_count(), 0);
-    assert_eq!(bob.opened_connection_count(), 2);
 
     Ok(())
 }
@@ -446,8 +428,6 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
                     }
                 }
 
-                assert_eq!(send_endpoint.opened_connection_count(), 1);
-
                 Ok::<_, Report>(())
             }
         }));
@@ -457,8 +437,6 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
         .await?
         .into_iter()
         .collect::<Result<_>>()?;
-
-    assert_eq!(server_endpoint.opened_connection_count(), 0);
 
     Ok(())
 }
@@ -603,7 +581,6 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
                     hash_results.is_empty(),
                     "verifier terminated before all results were verified"
                 );
-                assert_eq!(send_endpoint.opened_connection_count(), 1);
 
                 Ok::<_, Report>(())
             }
@@ -616,8 +593,6 @@ async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<(
             other => bail!("Error from test threads: {:?}", other),
         }
     }
-
-    assert_eq!(server_endpoint.opened_connection_count(), 0);
 
     Ok(())
 }
@@ -683,9 +658,6 @@ async fn many_messages() -> Result<()> {
 
     let _ = future::try_join_all(tasks).await?;
 
-    assert_eq!(send_endpoint.opened_connection_count(), 1);
-    assert_eq!(recv_endpoint.opened_connection_count(), 0);
-
     Ok(())
 }
 
@@ -722,11 +694,6 @@ async fn connection_attempts_to_bootstrap_contacts_should_succeed() -> Result<()
         }
     }
 
-    assert_eq!(ep1.opened_connection_count(), 0);
-    assert_eq!(ep2.opened_connection_count(), 0);
-    assert_eq!(ep3.opened_connection_count(), 0);
-    assert_eq!(ep.opened_connection_count(), 3);
-
     Ok(())
 }
 
@@ -740,9 +707,6 @@ async fn reachability() -> Result<()> {
     };
     let reachable_addr = ep2.public_addr();
     ep1.is_reachable(&reachable_addr).await?;
-
-    assert_eq!(ep1.opened_connection_count(), 1);
-    assert_eq!(ep2.opened_connection_count(), 0);
 
     Ok(())
 }
@@ -809,9 +773,6 @@ async fn client() -> Result<()> {
 
     // reconnecting should increment client's opened connection count
     let _ = client.connect_to(&server.public_addr()).await?;
-
-    assert_eq!(server.opened_connection_count(), 0);
-    assert_eq!(client.opened_connection_count(), 2);
 
     Ok(())
 }


### PR DESCRIPTION
- 7bd84df **chore: bump edition to 2021**

  The only change that affected us was that the Cargo resolver has changed
  to be version 2 by default. It turns out that this causes compiling
  without dev-dependencies to fail, since we were depending on
  `tiny-keccak` without specifying any hash function features. We don't
  actually use `tiny-keccak` in the library any more, just in the tests,
  so this has simple been removed from the main dependencies.

- cb37349 **chore: remove connection counting**

  Now the there is no connection pooling in the library, the number of
  opened connections is exactly the number of times `connect_to` has been
  called, plus `connect_to_any * peer_addrs.len()` (e.g. one opened
  connection per candidate peer). Basically there are no surprises now.
  
  It might have been nice to retain the assertions in the tests, however
  the above reasoning also applies for them, so this was mostly useful
  when transitioning from the connection pool.
  
  Since this was exposed only under an 'unstable' feature flag, this does
  not constitute a breaking change.
