### PR TITLE
Implement `Debug` for `Connection`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -167,6 +167,15 @@ impl Connection {
     }
 }
 
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connection")
+            .field("id", &self.id())
+            .field("remote_address", &self.remote_address())
+            .finish_non_exhaustive()
+    }
+}
+
 /// The sending API for a QUIC stream.
 pub struct SendStream {
     inner: quinn::SendStream,


### PR DESCRIPTION
- 9553dc6 **feat: implement `Debug` for `Connection`**

  The debug output includes the connection ID and the remote address.
  Non-exhaustive formatting is used to be clear that this is not a valid
  `Connection` representation.
