### PR TITLE
Better retries

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -1,0 +1,25 @@
+//! Utilities for working with retries driven by the [`backoff`](::backoff) crate.
+
+use backoff::backoff::Backoff;
+use std::time::Duration;
+
+/// A wrapper for an `&mut impl `[`Backoff`].
+///
+/// It's useful to be able to supply a reference to a [`Backoff`] in order to maintain the same
+/// retry 'context' across multiple operations. Sadly this isn't possible with the trait
+/// implementations in the `backoff` crate itself, since `Backoff` is not implement for mutable
+/// references.
+pub struct BackoffRef<'b, B: Backoff>(&'b mut B);
+
+impl<'b, B: Backoff> BackoffRef<'b, B> {
+    /// Construct a `BackoffRef` from a mutable reference to an implementor of [`Backoff`].
+    pub fn new(backoff: &'b mut B) -> Self {
+        Self(backoff)
+    }
+}
+
+impl<'b, B: Backoff> Backoff for BackoffRef<'b, B> {
+    fn next_backoff(&mut self) -> Option<Duration> {
+        Backoff::next_backoff(self.0)
+    }
+}

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -1,7 +1,7 @@
 //! Utilities for working with retries driven by the [`backoff`](::backoff) crate.
 
 use backoff::backoff::Backoff;
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
 /// A wrapper for an `&mut impl `[`Backoff`].
 ///
@@ -15,6 +15,34 @@ impl<'b, B: Backoff> BackoffRef<'b, B> {
     /// Construct a `BackoffRef` from a mutable reference to an implementor of [`Backoff`].
     pub fn new(backoff: &'b mut B) -> Self {
         Self(backoff)
+    }
+
+    /// Retry `operation` until permanent error or exhausting `self`.
+    pub async fn retry<Op, Fut, Ok, Err>(&mut self, mut operation: Op) -> Result<Ok, Err>
+    where
+        Op: FnMut(BackoffRef<'_, B>) -> Fut,
+        Fut: Future<Output = Result<Ok, backoff::Error<Err>>>,
+    {
+        loop {
+            // try the operation
+            match operation(BackoffRef(&mut self.0)).await {
+                Ok(value) => return Ok(value),
+                Err(backoff::Error::Transient(error)) => {
+                    // retry the transient error, if we have time remaining
+                    if let Some(duration) = self.next_backoff() {
+                        tokio::time::sleep(duration).await;
+                        continue;
+                    } else {
+                        // we're out of time, bail
+                        return Err(error);
+                    }
+                }
+                Err(backoff::Error::Permanent(error)) => {
+                    // we cannot retry permanent errors here
+                    return Err(error);
+                }
+            }
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@
 //! Configuration for `Endpoint`s.
 
 use serde::{Deserialize, Serialize};
-use std::{future::Future, net::IpAddr, sync::Arc, time::Duration};
+use std::{net::IpAddr, sync::Arc, time::Duration};
 
 /// Default for [`Config::idle_timeout`] (1 minute).
 ///
@@ -172,25 +172,16 @@ pub struct RetryConfig {
 }
 
 impl RetryConfig {
-    // Perform `op` and retry on errors as specified by this configuration.
-    //
-    // Note that `backoff::Error<E>` implements `From<E>` for any `E` by creating a
-    // `backoff::Error::Transient`, meaning that errors will be retried unless explicitly returning
-    // `backoff::Error::Permanent`.
-    pub(crate) fn retry<R, E, Fn, Fut>(&self, op: Fn) -> impl Future<Output = Result<R, E>>
-    where
-        Fn: FnMut() -> Fut,
-        Fut: Future<Output = Result<R, backoff::Error<E>>>,
-    {
-        let backoff = backoff::ExponentialBackoff {
+    /// Obtain an [`Backoff`](backoff::backoff::Backoff) implementor to use with retry APIs.
+    pub fn backoff(&self) -> impl backoff::backoff::Backoff {
+        backoff::ExponentialBackoff {
             initial_interval: self.initial_retry_interval,
             randomization_factor: self.retry_delay_rand_factor,
             multiplier: self.retry_delay_multiplier,
             max_interval: self.max_retry_interval,
             max_elapsed_time: Some(self.retrying_max_elapsed_time),
             ..Default::default()
-        };
-        backoff::future::retry(backoff, op)
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -132,10 +132,11 @@ pub struct Config {
     #[serde(default)]
     pub upnp_lease_duration: Option<Duration>,
 
-    /// Retry configurations for establishing connections and sending messages.
+    /// Default retry configuration for establishing connections and sending messages.
+    ///
     /// Determines the retry behaviour of requests, by setting the back off strategy used.
     #[serde(default)]
-    pub retry_config: RetryConfig,
+    pub default_retry_config: RetryConfig,
 }
 
 /// Retry configurations for establishing connections and sending messages.
@@ -217,7 +218,7 @@ pub(crate) struct InternalConfig {
     pub(crate) external_port: Option<u16>,
     pub(crate) external_ip: Option<IpAddr>,
     pub(crate) upnp_lease_duration: Duration,
-    pub(crate) retry_config: Arc<RetryConfig>,
+    pub(crate) default_retry_config: Arc<RetryConfig>,
 }
 
 impl InternalConfig {
@@ -239,7 +240,7 @@ impl InternalConfig {
             external_port: config.external_port,
             external_ip: config.external_ip,
             upnp_lease_duration,
-            retry_config: Arc::new(config.retry_config),
+            default_retry_config: Arc::new(config.default_retry_config),
         })
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -82,6 +82,11 @@ impl Connection {
         self.inner.remote_address()
     }
 
+    /// The default [`RetryConfig`] set for this connection.
+    pub fn default_retry_config(&self) -> Option<&RetryConfig> {
+        self.default_retry_config.as_deref()
+    }
+
     /// Send a message to the peer with default retry configuration.
     ///
     /// The message will be sent on a unidirectional QUIC stream, meaning the application is

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -228,6 +228,11 @@ impl Endpoint {
         self.public_addr.unwrap_or(self.local_addr)
     }
 
+    /// Get the default [`RetryConfig`] set for this endpoint.
+    pub fn default_retry_config(&self) -> &RetryConfig {
+        self.default_retry_config.as_ref()
+    }
+
     /// Connect to a peer.
     ///
     /// Atttempts to connect to a peer at the given address. Connection attempts are retried based

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
     unused_results
 )]
 
+pub mod backoff;
 pub mod config;
 mod connection;
 mod endpoint;

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -677,7 +677,7 @@ async fn connection_attempts_to_bootstrap_contacts_should_succeed() -> Result<()
         local_addr(),
         &contacts,
         Config {
-            retry_config: RetryConfig {
+            default_retry_config: RetryConfig {
                 retrying_max_elapsed_time: Duration::from_millis(500),
                 ..RetryConfig::default()
             },
@@ -720,7 +720,7 @@ async fn client() -> Result<()> {
     let client = Endpoint::new_client(
         local_addr(),
         Config {
-            retry_config: RetryConfig {
+            default_retry_config: RetryConfig {
                 retrying_max_elapsed_time: Duration::from_millis(500),
                 ..RetryConfig::default()
             },

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -37,7 +37,7 @@ pub(crate) async fn new_endpoint() -> Result<(
         local_addr(),
         &[],
         Config {
-            retry_config: RetryConfig {
+            default_retry_config: RetryConfig {
                 retrying_max_elapsed_time: Duration::from_millis(500),
                 ..RetryConfig::default()
             },


### PR DESCRIPTION
- bf2c26e **refactor!: rename `Config::retry_config` to `default_retry_config`**

  The plan is to introduce additional APIs to allow retries to be
  configured in all places that we perform retries. As such, the
  configured retry config will always behave as a default, and changing
  the name makes this clear.

- 027dc51 **refactor: improve retry APIs**

  This is an attempt to allow callers to maintain a 'retry context'
  throughout their own code and calls to `qp2p`. For example, it may be
  desired to retry an operation for 60s, regardless of where the failure
  occurs. Without a change such as this, callers would have to wrap their
  entire operation in a top level retry, and it becomes difficult to
  reason about where retries may occur and for how long.
  
  The APIs introduced here allow callers to supply an implementation of
  `backoff::backoff::Backoff`, which will be used to drive retries. That
  alone is insufficient to allow a 'retry context' to be maintained, but
  the included `qp2p::backoff::BackoffRef` utility struct allows a mutable
  reference to a `backoff::backoff::Backoff` to be passed.
