### PR TITLE
feat: add optional reason for closing a connection.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,7 @@ pub(crate) struct InternalConfig {
     pub(crate) forward_port: bool,
     pub(crate) external_port: Option<u16>,
     pub(crate) external_ip: Option<IpAddr>,
+    #[allow(dead_code)]
     pub(crate) upnp_lease_duration: Duration,
     pub(crate) retry_config: Arc<RetryConfig>,
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -145,8 +145,10 @@ impl Connection {
     /// This is not a graceful close - pending operations will fail immediately with
     /// [`ConnectionError::Closed`]`(`[`Close::Local`]`)`, and data on unfinished streams is not
     /// guaranteed to be delivered.
-    pub fn close(&self) {
-        self.inner.close(0u8.into(), b"");
+    pub fn close(&self, reason: Option<String>) {
+        let reason = reason
+            .unwrap_or_else(|| "The connection was closed intentionally by qp2p.".to_string());
+        self.inner.close(0u8.into(), &reason.into_bytes());
     }
 
     async fn send_uni(&self, msg: Bytes, priority: i32) -> Result<(), SendError> {


### PR DESCRIPTION
BREAKING_CHANGE: The close api now needs an optional reason passed in.

Here we can specifigy _why_ a connection was closed (or fallback to simply stating it was intentional and triggered via qp2p