### PR TITLE
fix(p2p_node): 'polo' reply processing

### DIFF
--- a/examples/p2p_node.rs
+++ b/examples/p2p_node.rs
@@ -53,7 +53,10 @@ async fn main() -> Result<()> {
                 .expect("Invalid SocketAddr.  Use the form 127.0.0.1:1234");
             let msg = Bytes::from(MSG_MARCO);
             println!("Sending to {:?} --> {:?}\n", peer, msg);
-            node.connect_to(&peer).await?.0.send(msg.clone()).await?;
+            let (conn, mut incoming) = node.connect_to(&peer).await?;
+            conn.send(msg.clone()).await?;
+            let reply = incoming.next().await?.unwrap();
+            println!("Received from {:?} --> {:?}", peer, reply);
         }
 
         println!("Done sending");


### PR DESCRIPTION
When trying to run the p2p_node example, I encountered a crash when polo is sent back to the peer:

```bash
---
Listening on: 127.0.0.1:38616
---


Received from 127.0.0.1:38091 --> b"marco"
Error: 
   0: Connection was lost when trying to send a message
   1: The connection was closed by application (error code: 0, reason: )

```

The client shows:

```bash
Sending to 127.0.0.1:38616 --> b"marco"

Done sending

---
Listening on: 127.0.0.1:38091
---

```

I was able to get it working with the following patch. I'm a beginner to this library,
so please feel free to recommend a different way to tackle this! I was aiming for
the simplest solution in this context.
