### PR TITLE
feat: Make Connection.id unique across all peers

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -71,11 +71,15 @@ impl Connection {
 
     /// A stable identifier for the connection.
     ///
-    /// This ID will not change for the lifetime of the connection. Note that the connection ID will
-    /// be different at each peer, so this is most useful for tracing connection activity within a
-    /// single peer.
-    pub fn id(&self) -> usize {
-        self.inner.stable_id()
+    /// This ID will not change for the lifetime of the connection to a given ip.
+    ///
+    /// The ID pulls the internal conneciton id and concats with the SocketAddr of
+    /// the peer. So this _should_ be unique per peer (without IP spoofing).
+    ///
+    pub fn id(&self) -> String {
+        let socket = self.remote_address();
+
+        format!("{}{}", socket, self.inner.stable_id())
     }
 
     /// The address of the remote peer.

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,7 +91,7 @@ pub enum ClientEndpointError {
 /// Errors that can cause connection loss.
 // This is a copy of `quinn::ConnectionError` without the `*Closed` variants, since we want to
 // separate them in our interface.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ConnectionError {
     /// The endpoint has been stopped.
     #[error("The endpoint has been stopped")]
@@ -199,12 +199,12 @@ impl From<quinn::ConnectionError> for ConnectionError {
 }
 
 /// An internal configuration error encountered by [`Endpoint`](crate::Endpoint) connect methods.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[error(transparent)]
 pub struct InternalConfigError(quinn::ConnectError);
 
 /// The reason a connection was closed.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Close {
     /// This application closed the connection.
     Local,
@@ -270,7 +270,7 @@ impl From<quinn::ConnectionClose> for Close {
 /// An opaque error code indicating a transport failure.
 ///
 /// This can be turned to a string via its `Debug` and `Display` impls, but is otherwise opaque.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TransportErrorCode(quinn_proto::TransportErrorCode);
 
 impl fmt::Debug for TransportErrorCode {

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -117,7 +117,7 @@ impl fmt::Display for WireMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             WireMsg::UserMsg(ref m) => {
-                write!(f, "WireMsg::UserMsg({})", utils::bin_data_format(&*m))
+                write!(f, "WireMsg::UserMsg({})", utils::bin_data_format(m))
             }
             WireMsg::EndpointEchoReq => write!(f, "WireMsg::EndpointEchoReq"),
             WireMsg::EndpointEchoResp(ref sa) => write!(f, "WireMsg::EndpointEchoResp({})", sa),


### PR DESCRIPTION
BREAKING CHANGE: the connection id is now a string.

The quinn.stable_id is prefaced with the SockeetAddr of the
peer, so this should provide a globally unique id now.