### PR TITLE
refactor(api)!: refactoring and addition of new Error types to the public API

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -254,7 +254,7 @@ pub(crate) struct InternalConfig {
 
 impl InternalConfig {
     pub(crate) fn try_from_config(config: Config) -> Result<Self> {
-        let default_idle_timeout: IdleTimeout = IdleTimeout::try_from(DEFAULT_IDLE_TIMEOUT)?; // 60s
+        let default_idle_timeout: IdleTimeout = IdleTimeout::try_from(DEFAULT_IDLE_TIMEOUT)?;
 
         // let's convert our duration to quinn's IdleTimeout
         let idle_timeout = config

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::wire_msg::WireMsg;
 use crate::config::ConfigError;
 #[cfg(feature = "igd")]
 use crate::igd::IgdError;
@@ -301,6 +300,24 @@ pub enum RpcError {
     /// Failed to receive the response.
     #[error("Failed to receive the response")]
     Recv(#[from] RecvError),
+
+    /// Endpoint echo response was not received
+    #[error("Endpoint echo response from {peer} was not received. Response received instead: {response:?}")]
+    EchoResponseMissing {
+        /// Peer the response was expected from
+        peer: SocketAddr,
+        /// Response received instead, in any
+        response: Option<String>,
+    },
+
+    /// Endpoint verification response was not received
+    #[error("Endpoint verification response from {peer} was not received. Response received instead: {response:?}")]
+    EndpointVerificationRespMissing {
+        /// Peer the response was expected from
+        peer: SocketAddr,
+        /// Response received instead, in any
+        response: Option<String>,
+    },
 }
 
 // Treating `ConnectionError`s as happening on send works because we would only encounter them
@@ -327,13 +344,17 @@ impl From<tokio::time::error::Elapsed> for RpcError {
 /// Errors that can occur when sending messages.
 #[derive(Debug, Error)]
 pub enum SendError {
+    /// The serialised message is too long
+    #[error("The serialized message is too long ({0} bytes, max: 4 GiB)")]
+    MessageTooLong(usize),
+
     /// Failed to serialize message.
     ///
     /// This likely indicates a bug in the library, since serializing to bytes should be infallible.
     /// Limitations in the serde API mean we cannot verify this statically, and we don't want to
     /// introduce potential panics.
     #[error("Failed to serialize message")]
-    Serialization(#[from] SerializationError),
+    Serialization(#[from] bincode::Error),
 
     /// Connection was lost when trying to send a message.
     #[error("Connection was lost when trying to send a message")]
@@ -342,12 +363,6 @@ pub enum SendError {
     /// Stream was lost when trying to send a message.
     #[error("Stream was lost when trying to send a message")]
     StreamLost(#[source] StreamError),
-}
-
-impl From<bincode::Error> for SendError {
-    fn from(error: bincode::Error) -> Self {
-        Self::Serialization(SerializationError(error))
-    }
 }
 
 impl From<quinn::ConnectionError> for SendError {
@@ -372,9 +387,25 @@ impl From<quinn::WriteError> for SendError {
 /// Errors that can occur when receiving messages.
 #[derive(Debug, Error)]
 pub enum RecvError {
+    /// Message received has an empty payload
+    #[error("Message received from peer has an empty payload")]
+    EmptyMsgPayload,
+
+    /// Not enough bytes were received to be a valid message
+    #[error("Received too few bytes for message")]
+    NotEnoughBytes,
+
     /// Failed to deserialize message.
     #[error("Failed to deserialize message")]
-    Serialization(#[from] SerializationError),
+    Serialization(#[from] bincode::Error),
+
+    /// Message type flag found in message header is invalid
+    #[error("Invalid message type flag found in message header: {0}")]
+    InvalidMsgTypeFlag(u8),
+
+    /// Type of message received is unexpected
+    #[error("Type of message received is unexpected: {0}")]
+    UnexpectedMsgReceived(String),
 
     /// Connection was lost when trying to receive a message.
     #[error("Connection was lost when trying to receive a message")]
@@ -388,12 +419,6 @@ pub enum RecvError {
 impl From<quinn::ConnectionError> for RecvError {
     fn from(error: quinn::ConnectionError) -> Self {
         Self::ConnectionLost(error.into())
-    }
-}
-
-impl From<bincode::Error> for RecvError {
-    fn from(error: bincode::Error) -> Self {
-        Self::Serialization(SerializationError(error))
     }
 }
 
@@ -415,34 +440,8 @@ impl From<quinn::ReadError> for RecvError {
 impl From<quinn::ReadExactError> for RecvError {
     fn from(error: quinn::ReadExactError) -> Self {
         match error {
-            quinn::ReadExactError::FinishedEarly => Self::Serialization(SerializationError::new(
-                "Received too few bytes for message",
-            )),
+            quinn::ReadExactError::FinishedEarly => Self::NotEnoughBytes,
             quinn::ReadExactError::ReadError(error) => error.into(),
-        }
-    }
-}
-
-/// Failed to (de)serialize message.
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct SerializationError(bincode::Error);
-
-impl SerializationError {
-    /// Construct a `SerializationError` with an arbitrary message.
-    pub(crate) fn new(message: impl ToString) -> Self {
-        Self(bincode::ErrorKind::Custom(message.to_string()).into())
-    }
-
-    /// Construct a `SerializationError` for an unexpected message.
-    pub(crate) fn unexpected(actual: &Option<WireMsg>) -> Self {
-        if let Some(actual) = actual {
-            Self::new(format!(
-                "The message received was not the expected one: {}",
-                actual
-            ))
-        } else {
-            Self::new("Unexpected end of stream")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,7 @@ pub use endpoint::{Endpoint, IncomingConnections};
 pub use error::UpnpError;
 pub use error::{
     ClientEndpointError, Close, ConnectionError, EndpointError, InternalConfigError, RecvError,
-    RpcError, SendError, SerializationError, StreamError, TransportErrorCode,
-    UnsupportedStreamOperation,
+    RpcError, SendError, StreamError, TransportErrorCode, UnsupportedStreamOperation,
 };
 pub use wire_msg::UsrMsgBytes;
 


### PR DESCRIPTION
- In many cases the API was returning a `SerialisationError` type upon receiving messages of unexpected type, thus these errors were misleading. This PR introduces specific error types for those scenarios which shall make it clearer for the caller, also enabling proper error handling for those cases.
- The `RecvStream::next` public API now returns `Result<Option<UsrMsgBytes>, RecvError>` instead of `Result<UsrMsgBytes, RecvError>` which allows the caller to realise when the stream was finished as opposed to any error that could occur when attempting to read from it.