### PR TITLE
fix(api)!: don't treat any type of errors as benign

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -139,26 +139,6 @@ pub enum ConnectionError {
     Closed(Close),
 }
 
-impl ConnectionError {
-    // A 'benign' connection error is one that does not represent an error on the connection, but
-    // rather a natural change of state. This may still be an error for the caller (e.g. if the
-    // connection is closed when trying to send a message), but not always (e.g. if the connection
-    // closes during a message receive loop, we could quietly end the stream instead). This method
-    // helps to centralise that discrimination.
-    pub(crate) fn is_benign(&self) -> bool {
-        matches!(
-            self,
-            // We expect that timeouts will be used to naturally close connections once they are
-            // idle, so we treat it as benign.
-            Self::TimedOut |
-            // A graceful close from our end.
-            Self::Closed(Close::Local) |
-            // A graceful close from the peer, with the default code 0
-            Self::Closed(Close::Application { error_code: 0, .. })
-        )
-    }
-}
-
 impl From<quinn::ConnectError> for ConnectionError {
     fn from(error: quinn::ConnectError) -> Self {
         match error {

--- a/src/wire_msg.rs
+++ b/src/wire_msg.rs
@@ -46,17 +46,7 @@ impl WireMsg {
     ) -> Result<Option<Self>, RecvError> {
         let mut header_bytes = [0; MSG_HEADER_LEN];
         match recv.read(&mut header_bytes).err_into().await {
-            Err(RecvError::ConnectionLost(error)) if error.is_benign() => {
-                // We ignore 'benign' connection loss for the initial read, this follows from the
-                // understanding that quinn would always yield any successfully read bytes, so we
-                // would move further into the function, which will always propagated encountered
-                // errors.
-                return Ok(None);
-            }
-            Err(error) => {
-                // Any other error would indicate a real issue, so return it
-                return Err(error);
-            }
+            Err(error) => return Err(error),
             Ok(None) => return Ok(None),
             Ok(Some(len)) => {
                 if len < MSG_HEADER_LEN {


### PR DESCRIPTION
BREAKING CHANGE: Currently when an error occurs upon trying to read from a stream, we swallow some of the errors assuming them benign, as if the connection was just nicely closed. It'll be better to report the error upwards so the caller/user of this lib can be aware of it since it knows much better the context where it's happening to make any decision.