### PR TITLE
refactor(conn): do not filter any error upon trying to finish a uni-stream

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -121,7 +121,7 @@ pub enum ConnectionError {
     TimedOut,
 
     /// The connection was closed.
-    #[error("The connection was closed by {0}")]
+    #[error("The connection was closed, {0}")]
     Closed(Close),
 }
 


### PR DESCRIPTION
BREAKING CHANGE: if a uni-stream was already closed (perhaps by the peer) upon trying to finish it, we used to ignore the error.