### PR TITLE
refactor(conn): removing redundant Connection::send_uni public API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -121,7 +121,7 @@ pub enum ConnectionError {
     TimedOut,
 
     /// The connection was closed.
-    #[error("The connection was closed by {0}")]
+    #[error("The connection was closed, {0}")]
     Closed(Close),
 }
 


### PR DESCRIPTION
Minor improvemetns/corrections to some log msgs.

BREAKING CHANGE: the `Connection::send_uni` public API has been removed since it has the same implementation as the `Connection::send_with` API.