### PR TITLE
fix: generate random Bytes faster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ structopt = {version = "0.3.25", optional = true}
 [dev-dependencies]
 color-eyre = "0.5.11"
 ctor = "0.1.20"
-rand = "~0.7.3"
+rand = { version = "~0.7.3", features = [ "small_rng" ] }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.2.19"

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -481,6 +481,7 @@ async fn multiple_connections_with_many_concurrent_messages() -> Result<()> {
     Ok(())
 }
 
+#[tracing_test::traced_test]
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_connections_with_many_larger_concurrent_messages() -> Result<()> {
     use futures::future;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,6 +10,7 @@
 use crate::{Config, Connection, ConnectionIncoming, Endpoint, IncomingConnections};
 use bytes::Bytes;
 use color_eyre::eyre::Result;
+use rand::{distributions::Standard, rngs, Rng, SeedableRng};
 use std::{
     net::{Ipv4Addr, SocketAddr},
     time::Duration,
@@ -63,7 +64,10 @@ pub(crate) fn local_addr() -> SocketAddr {
 }
 
 pub(crate) fn random_msg(size: usize) -> Bytes {
-    let random_bytes: Vec<u8> = (0..size).map(|_| rand::random::<u8>()).collect();
+    let random_bytes: Vec<u8> = rngs::SmallRng::from_entropy()
+        .sample_iter(Standard)
+        .take(size)
+        .collect();
     Bytes::from(random_bytes)
 }
 


### PR DESCRIPTION
One test took a long time to complete, which was mainly due to generating 100 random 1MiB byte arrays taking very long.
